### PR TITLE
Expose aggregate election timetable

### DIFF
--- a/tests/test_election.py
+++ b/tests/test_election.py
@@ -1,0 +1,18 @@
+from datetime import date
+from typing import Dict
+
+from uk_election_timetables.calendars import Country
+from uk_election_timetables.election import Election
+from uk_election_timetables.election_ids import from_election_id
+
+
+def test_timetable_sopn_publish_date():
+    election = from_election_id("parl.2019-02-21", country=Country.ENGLAND)
+
+    sopn_publish_date = lookup(election, "List of candidates published")
+
+    assert sopn_publish_date["date"] == date(2019, 1, 25)
+
+
+def lookup(election: Election, label: str) -> Dict:
+    return next(entry for entry in election.timetable if entry["label"] == label)

--- a/uk_election_timetables/election.py
+++ b/uk_election_timetables/election.py
@@ -15,6 +15,11 @@ class Election(metaclass=ABCMeta):
 
     @property
     def timetable(self) -> List[Dict]:
+        """
+        An aggregate of all known dates for the specific election type.
+
+        :return: a list representing the entire timetable for this particular election.
+        """
         return [
             {
                 "label": "List of candidates published",

--- a/uk_election_timetables/election.py
+++ b/uk_election_timetables/election.py
@@ -1,5 +1,6 @@
 from abc import ABCMeta, abstractmethod
 from datetime import date
+from typing import Dict, List
 
 from uk_election_timetables.calendars import UnitedKingdomBankHolidays
 
@@ -11,3 +12,12 @@ class Election(metaclass=ABCMeta):
     @abstractmethod
     def sopn_publish_date(self) -> date:
         pass
+
+    @property
+    def timetable(self) -> List[Dict]:
+        return [
+            {
+                "label": "List of candidates published",
+                "date": self.sopn_publish_date,
+            }
+        ]


### PR DESCRIPTION
This PR creates a `timetable` property on `Election` objects, which returns a `Dict[str,Dict]` representing known dates and their "names".

The intention is that this property will enable creation of user-facing tables / grids with entire timetables for a given election.﻿

Resolves https://github.com/DemocracyClub/uk-election-timetables/issues/7
