### PR TITLE
feat: Register to vote deadline

### DIFF
--- a/tests/elections/test_greater_london_assembly.py
+++ b/tests/elections/test_greater_london_assembly.py
@@ -14,3 +14,10 @@ def test_publish_date_mayor_london():
     publish_date = GreaterLondonAssemblyElection(date(2016, 5, 5)).sopn_publish_date
 
     assert publish_date == date(2016, 4, 1)
+
+
+# Reference election: gla.2021-05-06
+def test_registration_deadline_london_assembly():
+    election = GreaterLondonAssemblyElection(date(2021, 5, 6))
+
+    assert election.registration_deadline == date(2021, 4, 19)

--- a/tests/elections/test_local.py
+++ b/tests/elections/test_local.py
@@ -23,3 +23,10 @@ def test_publish_date_local_election_england():
     election = LocalElection(date(2019, 6, 6), country=Country.ENGLAND)
 
     assert election.sopn_publish_date == date(2019, 5, 10)
+
+
+# Reference election: local.2021-05-06
+def test_registration_deadline_local_election_england():
+    election = LocalElection(date(2021, 5, 6), country=Country.ENGLAND)
+
+    assert election.registration_deadline == date(2021, 4, 19)

--- a/tests/elections/test_mayoral.py
+++ b/tests/elections/test_mayoral.py
@@ -8,3 +8,10 @@ def test_publish_date_mayor():
     election = MayoralElection(date(2017, 5, 4))
 
     assert election.sopn_publish_date == date(2017, 4, 4)
+
+
+# Reference election: mayor.2021-05-06
+def test_registration_deadline_mayor():
+    election = MayoralElection(date(2021, 5, 6))
+
+    assert election.registration_deadline == date(2021, 4, 19)

--- a/tests/elections/test_police_and_crime_commissioner.py
+++ b/tests/elections/test_police_and_crime_commissioner.py
@@ -8,3 +8,10 @@ def test_publish_date_police_and_crime_commissioner():
     election = PoliceAndCrimeCommissionerElection(date(2016, 5, 5))
 
     assert election.sopn_publish_date == date(2016, 4, 8)
+
+
+# Reference election: pcc.2021-05-06
+def test_registration_deadline_police_and_crime_commissioner():
+    election = PoliceAndCrimeCommissionerElection(date(2021, 5, 6))
+
+    assert election.registration_deadline == date(2021, 4, 19)

--- a/tests/elections/test_scottish_parliament.py
+++ b/tests/elections/test_scottish_parliament.py
@@ -10,3 +10,10 @@ def test_publish_date_scottish_parliament():
     publish_date = ScottishParliamentElection(date(2016, 5, 5)).sopn_publish_date
 
     assert publish_date == date(2016, 4, 1)
+
+
+# Reference election: sp.2021-05-06
+def test_registration_deadline_scottish_parliament():
+    election = ScottishParliamentElection(date(2021, 5, 6))
+
+    assert election.registration_deadline == date(2021, 4, 19)

--- a/tests/elections/test_senedd_cymru.py
+++ b/tests/elections/test_senedd_cymru.py
@@ -8,3 +8,10 @@ def test_publish_date_senedd_cymru():
     publish_date = SeneddCymruElection(date(2016, 5, 5)).sopn_publish_date
 
     assert publish_date == date(2016, 4, 7)
+
+
+# Reference election: senedd.2021-05-06
+def test_registration_deadline_senedd_cymru():
+    election = SeneddCymruElection(date(2021, 5, 6))
+
+    assert election.registration_deadline == date(2021, 4, 19)

--- a/tests/test_election.py
+++ b/tests/test_election.py
@@ -14,5 +14,13 @@ def test_timetable_sopn_publish_date():
     assert sopn_publish_date["date"] == date(2019, 1, 25)
 
 
+def test_timetable_registration_deadline():
+    election = from_election_id("local.2021-05-06", country=Country.ENGLAND)
+
+    sopn_publish_date = lookup(election, "Register to vote deadline")
+
+    assert sopn_publish_date["date"] == date(2021, 4, 19)
+
+
 def lookup(election: Election, label: str) -> Dict:
     return next(entry for entry in election.timetable if entry["label"] == label)

--- a/uk_election_timetables/election.py
+++ b/uk_election_timetables/election.py
@@ -2,7 +2,11 @@ from abc import ABCMeta, abstractmethod
 from datetime import date
 from typing import Dict, List
 
-from uk_election_timetables.calendars import UnitedKingdomBankHolidays, Country
+from uk_election_timetables.calendars import (
+    UnitedKingdomBankHolidays,
+    Country,
+    working_days_before,
+)
 
 
 class Election(metaclass=ABCMeta):
@@ -16,6 +20,17 @@ class Election(metaclass=ABCMeta):
     @abstractmethod
     def sopn_publish_date(self) -> date:
         pass
+
+    @property
+    def registration_deadline(self) -> date:
+        """
+        Calculates the voter registration deadline for this Election
+
+        This explained in a `background note from the Electoral Commission <https://www.electoralcommission.org.uk/media/2457>`_
+
+        :return: a datetime representing the voter registration deadline
+        """
+        return working_days_before(self.poll_date, 12, self._calendar())
 
     @property
     def timetable(self) -> List[Dict]:

--- a/uk_election_timetables/election.py
+++ b/uk_election_timetables/election.py
@@ -30,3 +30,6 @@ class Election(metaclass=ABCMeta):
                 "date": self.sopn_publish_date,
             }
         ]
+
+    def _calendar(self):
+        return self.BANK_HOLIDAY_CALENDAR.from_country(self.country)

--- a/uk_election_timetables/election.py
+++ b/uk_election_timetables/election.py
@@ -2,11 +2,15 @@ from abc import ABCMeta, abstractmethod
 from datetime import date
 from typing import Dict, List
 
-from uk_election_timetables.calendars import UnitedKingdomBankHolidays
+from uk_election_timetables.calendars import UnitedKingdomBankHolidays, Country
 
 
 class Election(metaclass=ABCMeta):
     BANK_HOLIDAY_CALENDAR = UnitedKingdomBankHolidays()
+
+    def __init__(self, poll_date: date, country: Country):
+        self.poll_date = poll_date
+        self.country = country
 
     @property
     @abstractmethod

--- a/uk_election_timetables/election.py
+++ b/uk_election_timetables/election.py
@@ -41,6 +41,10 @@ class Election(metaclass=ABCMeta):
         """
         return [
             {
+                "label": "Register to vote deadline",
+                "date": self.registration_deadline,
+            },
+            {
                 "label": "List of candidates published",
                 "date": self.sopn_publish_date,
             }

--- a/uk_election_timetables/elections/greater_london_assembly.py
+++ b/uk_election_timetables/elections/greater_london_assembly.py
@@ -1,12 +1,12 @@
 from datetime import date
 
-from uk_election_timetables.calendars import working_days_before
+from uk_election_timetables.calendars import working_days_before, Country
 from uk_election_timetables.election import Election
 
 
 class GreaterLondonAssemblyElection(Election):
     def __init__(self, poll_date: date):
-        self.poll_date = poll_date
+        Election.__init__(self, poll_date, Country.ENGLAND)
 
     @property
     def sopn_publish_date(self) -> date:

--- a/uk_election_timetables/elections/greater_london_assembly.py
+++ b/uk_election_timetables/elections/greater_london_assembly.py
@@ -18,6 +18,4 @@ class GreaterLondonAssemblyElection(Election):
         :param poll_date: a datetime representing the date of the poll
         :return: a datetime representing the expected publish date
         """
-        return working_days_before(
-            self.poll_date, 23, type(self).BANK_HOLIDAY_CALENDAR.england_and_wales()
-        )
+        return working_days_before(self.poll_date, 23, super()._calendar())

--- a/uk_election_timetables/elections/local.py
+++ b/uk_election_timetables/elections/local.py
@@ -5,10 +5,6 @@ from uk_election_timetables.election import Election
 
 
 class LocalElection(Election):
-    def __init__(self, poll_date: date, country: Country):
-        self.poll_date = poll_date
-        self.country = country
-
     @property
     def sopn_publish_date(self) -> date:
         """

--- a/uk_election_timetables/elections/local.py
+++ b/uk_election_timetables/elections/local.py
@@ -33,5 +33,5 @@ class LocalElection(Election):
         return working_days_before(
             self.poll_date,
             days_prior,
-            type(self).BANK_HOLIDAY_CALENDAR.from_country(self.country),
+            super()._calendar(),
         )

--- a/uk_election_timetables/elections/mayor.py
+++ b/uk_election_timetables/elections/mayor.py
@@ -1,12 +1,12 @@
 from datetime import date
 
-from uk_election_timetables.calendars import working_days_before
+from uk_election_timetables.calendars import working_days_before, Country
 from uk_election_timetables.election import Election
 
 
 class MayoralElection(Election):
     def __init__(self, poll_date: date):
-        self.poll_date = poll_date
+        Election.__init__(self, poll_date, Country.ENGLAND)
 
     @property
     def sopn_publish_date(self) -> date:

--- a/uk_election_timetables/elections/mayor.py
+++ b/uk_election_timetables/elections/mayor.py
@@ -18,6 +18,4 @@ class MayoralElection(Election):
         :param poll_date: a datetime representing the date of the poll
         :return: a datetime representing the expected publish date
         """
-        return working_days_before(
-            self.poll_date, 19, type(self).BANK_HOLIDAY_CALENDAR.england_and_wales()
-        )
+        return working_days_before(self.poll_date, 19, super()._calendar())

--- a/uk_election_timetables/elections/northern_ireland_assembly.py
+++ b/uk_election_timetables/elections/northern_ireland_assembly.py
@@ -18,6 +18,4 @@ class NorthernIrelandAssemblyElection(Election):
         :param poll_date: a datetime representing the date of the poll
         :return: a datetime representing the expected publish date
         """
-        return working_days_before(
-            self.poll_date, 16, type(self).BANK_HOLIDAY_CALENDAR.northern_ireland()
-        )
+        return working_days_before(self.poll_date, 16, super()._calendar())

--- a/uk_election_timetables/elections/northern_ireland_assembly.py
+++ b/uk_election_timetables/elections/northern_ireland_assembly.py
@@ -1,12 +1,12 @@
 from datetime import date
 
-from uk_election_timetables.calendars import working_days_before
+from uk_election_timetables.calendars import working_days_before, Country
 from uk_election_timetables.election import Election
 
 
 class NorthernIrelandAssemblyElection(Election):
     def __init__(self, poll_date: date):
-        self.poll_date = poll_date
+        Election.__init__(self, poll_date, Country.NORTHERN_IRELAND)
 
     @property
     def sopn_publish_date(self) -> date:

--- a/uk_election_timetables/elections/police_and_crime_commissioner.py
+++ b/uk_election_timetables/elections/police_and_crime_commissioner.py
@@ -1,12 +1,12 @@
 from datetime import date
 
-from uk_election_timetables.calendars import working_days_before
+from uk_election_timetables.calendars import working_days_before, Country
 from uk_election_timetables.election import Election
 
 
 class PoliceAndCrimeCommissionerElection(Election):
     def __init__(self, poll_date: date):
-        self.poll_date = poll_date
+        Election.__init__(self, poll_date, Country.ENGLAND)
 
     @property
     def sopn_publish_date(self) -> date:

--- a/uk_election_timetables/elections/police_and_crime_commissioner.py
+++ b/uk_election_timetables/elections/police_and_crime_commissioner.py
@@ -18,6 +18,4 @@ class PoliceAndCrimeCommissionerElection(Election):
         :param poll_date: a datetime representing the date of the poll
         :return: a datetime representing the expected publish date
         """
-        return working_days_before(
-            self.poll_date, 18, type(self).BANK_HOLIDAY_CALENDAR.england_and_wales()
-        )
+        return working_days_before(self.poll_date, 18, super()._calendar())

--- a/uk_election_timetables/elections/scottish_parliament.py
+++ b/uk_election_timetables/elections/scottish_parliament.py
@@ -18,6 +18,4 @@ class ScottishParliamentElection(Election):
         :param poll_date: a datetime representing the date of the poll
         :return: a datetime representing the expected publish date
         """
-        return working_days_before(
-            self.poll_date, 23, type(self).BANK_HOLIDAY_CALENDAR.scotland()
-        )
+        return working_days_before(self.poll_date, 23, super()._calendar())

--- a/uk_election_timetables/elections/scottish_parliament.py
+++ b/uk_election_timetables/elections/scottish_parliament.py
@@ -1,12 +1,12 @@
 from datetime import date
 
-from uk_election_timetables.calendars import working_days_before
+from uk_election_timetables.calendars import working_days_before, Country
 from uk_election_timetables.election import Election
 
 
 class ScottishParliamentElection(Election):
     def __init__(self, poll_date: date):
-        self.poll_date = poll_date
+        Election.__init__(self, poll_date, Country.SCOTLAND)
 
     @property
     def sopn_publish_date(self) -> date:

--- a/uk_election_timetables/elections/senedd_cymru.py
+++ b/uk_election_timetables/elections/senedd_cymru.py
@@ -1,12 +1,12 @@
 from datetime import date
 
-from uk_election_timetables.calendars import working_days_before
+from uk_election_timetables.calendars import working_days_before, Country
 from uk_election_timetables.election import Election
 
 
 class SeneddCymruElection(Election):
     def __init__(self, poll_date: date):
-        self.poll_date = poll_date
+        Election.__init__(self, poll_date, Country.WALES)
 
     @property
     def sopn_publish_date(self) -> date:

--- a/uk_election_timetables/elections/senedd_cymru.py
+++ b/uk_election_timetables/elections/senedd_cymru.py
@@ -18,6 +18,4 @@ class SeneddCymruElection(Election):
         :param poll_date: a datetime representing the date of the poll
         :return: a datetime representing the expected publish date
         """
-        return working_days_before(
-            self.poll_date, 19, type(self).BANK_HOLIDAY_CALENDAR.england_and_wales()
-        )
+        return working_days_before(self.poll_date, 19, super()._calendar())

--- a/uk_election_timetables/elections/uk_parliament.py
+++ b/uk_election_timetables/elections/uk_parliament.py
@@ -1,4 +1,5 @@
 from datetime import date
+from typing import Optional
 
 from uk_election_timetables.calendars import working_days_before, Country
 from uk_election_timetables.election import Election
@@ -6,8 +7,7 @@ from uk_election_timetables.election import Election
 
 class UKParliamentElection(Election):
     def __init__(self, poll_date: date, country: Country = None):
-        self.poll_date = poll_date
-        self.country = country
+        Election.__init__(self, poll_date, country)
 
     @property
     def sopn_publish_date(self) -> date:


### PR DESCRIPTION
This PR adds the register to vote deadline to the library.

This required some refactoring - the base class, `Election`, needed knowledge of the country it is being run in so as to calculate the correct date.

The new `registration_deadline` method is on the base class else we would be duplicating exactly the same method in all classes.

This PR resolves https://github.com/DemocracyClub/uk-election-timetables/issues/4