### PR TITLE
fix: Correct SoPN publish date for GLA

### DIFF
--- a/tests/elections/test_greater_london_assembly.py
+++ b/tests/elections/test_greater_london_assembly.py
@@ -6,14 +6,14 @@ from uk_election_timetables.elections import GreaterLondonAssemblyElection
 def test_publish_date_greater_london_assembly():
     publish_date = GreaterLondonAssemblyElection(date(2016, 5, 5)).sopn_publish_date
 
-    assert publish_date == date(2016, 4, 1)
+    assert publish_date == date(2016, 4, 4)
 
 
 # Reference election: mayor.london.2016-05-05
 def test_publish_date_mayor_london():
     publish_date = GreaterLondonAssemblyElection(date(2016, 5, 5)).sopn_publish_date
 
-    assert publish_date == date(2016, 4, 1)
+    assert publish_date == date(2016, 4, 4)
 
 
 # Reference election: gla.2021-05-06

--- a/uk_election_timetables/elections/greater_london_assembly.py
+++ b/uk_election_timetables/elections/greater_london_assembly.py
@@ -18,4 +18,4 @@ class GreaterLondonAssemblyElection(Election):
         :param poll_date: a datetime representing the date of the poll
         :return: a datetime representing the expected publish date
         """
-        return working_days_before(self.poll_date, 23, super()._calendar())
+        return working_days_before(self.poll_date, 22, super()._calendar())


### PR DESCRIPTION
This PR brings the Greater London Assembly SoPN publish date in line with a timetable recently published by the Electoral Commission.

Failing tests are corrected, and the logic around testing historic sopn date ranges has been changed to calculate working days rather than exact days.