### PR TITLE
Keep historic bank holidays when updating bank-holidays.json

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,9 +33,12 @@ jobs:
       - checkout
       - python/install-packages:
           pkg-manager: pip
-          # app-dir: ~/project/package-directory/  # If you're requirements.txt isn't in the root directory.
+          # app-dir: ~/project/package-directory/  # If your requirements.txt isn't in the root directory.
           # pip-dependency-file: test-requirements.txt  # if you have a different name for your requirements file, maybe one that combines your runtime and test requirements.
       - run:
           name: Run tests
           # This assumes pytest is installed via the install-package step above
           command: pytest
+      - run:
+          name: Black
+          command: black --check .

--- a/.github/workflows/check-for-bank-holiday-updates.yml
+++ b/.github/workflows/check-for-bank-holiday-updates.yml
@@ -18,9 +18,7 @@ jobs:
       run: |
         set +e
         
-        curl -XGET https://www.gov.uk/bank-holidays.json -o current.json
-
-        diff --brief current.json uk_election_timetables/bank-holidays.json
+        python manage_bank_holidays.py --diff
 
         if [[ $? -ne 0 ]]; then
           echo "New bank holiday JSON is live"

--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ election = UKParliamentElection(date(2019, 2, 21))
 print(election.sopn_publish_date) # date(2019, 1, 25)
 ```
 
+## Updating Bank Holiday Dates
+This project checks daily for additions to the government bank holiday dataset at https://www.gov.uk/bank-holidays.json. When an addition is identified in the .gov file, this project will automatically create a GitHub issue to update our local bank holiday dataset.
+
+To update `bank-holidays.json` with additions from the government supplied file, run the following within your venv:
+```commandline
+python manage_bank_holidays.py --update
+```
+
 ## Documentation
 
 Hosted by readthedocs at [https://uk-election-timetables.readthedocs.io/](https://uk-election-timetables.readthedocs.io/en/latest/overview.html)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -2,71 +2,68 @@
 
 import os
 import sys
-sys.path.insert(0, os.path.abspath('..'))
 
-project = 'uk-election-timetables'
-copyright = '2020, Alex Wilson'
-author = 'Alex Wilson'
+sys.path.insert(0, os.path.abspath(".."))
+
+project = "uk-election-timetables"
+copyright = "2020, Alex Wilson"
+author = "Alex Wilson"
 
 # The short X.Y version
-version = '2.2'
+version = "2.2"
 # The full version, including alpha/beta/rc tags
-release = '2.2.4'
+release = "2.2.4"
 
 
 # -- General configuration ---------------------------------------------------
 
-extensions = [
-    'sphinx.ext.autodoc',
-    'recommonmark',
-    'sphinx_markdown_tables'
-]
+extensions = ["sphinx.ext.autodoc", "recommonmark", "sphinx_markdown_tables"]
 
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
-source_suffix = ['.rst', '.md']
+source_suffix = [".rst", ".md"]
 
 html_theme_options = {
-    'logo_only': False,
-    'display_version': True,
-    'prev_next_buttons_location': 'bottom',
-    'style_external_links': False,
+    "logo_only": False,
+    "display_version": True,
+    "prev_next_buttons_location": "bottom",
+    "style_external_links": False,
     # Toc options
-    'collapse_navigation': True,
-    'sticky_navigation': True,
-    'navigation_depth': 4,
-    'includehidden': True,
-    'titles_only': False
+    "collapse_navigation": True,
+    "sticky_navigation": True,
+    "navigation_depth": 4,
+    "includehidden": True,
+    "titles_only": False,
 }
 
 
-master_doc = 'index'
+master_doc = "index"
 
 language = None
 
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 pygments_style = None
 
 
 # -- Options for HTML output -------------------------------------------------
 
-html_theme = 'sphinx_rtd_theme'
+html_theme = "sphinx_rtd_theme"
 
-html_static_path = ['_static']
+html_static_path = ["_static"]
 
 
 # -- Options for HTMLHelp output ---------------------------------------------
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'uk-election-timetablesdoc'
+htmlhelp_basename = "uk-election-timetablesdoc"
 
 # -- Options for Epub output -------------------------------------------------
 
 # Bibliographic Dublin Core info.
 
 epub_title = project
-epub_exclude_files = ['search.html']
+epub_exclude_files = ["search.html"]
 
 
 # -- Extension configuration -------------------------------------------------

--- a/manage_bank_holidays.py
+++ b/manage_bank_holidays.py
@@ -11,6 +11,7 @@ if __name__ == '__main__':
     if args.diff:
         try:
             additions_count: int = diff_bank_holidays()
+            print(f"No. of additions: {additions_count}")
             sys.exit(additions_count)
         except Exception as ex:
             print(f"Unable to diff files")

--- a/manage_bank_holidays.py
+++ b/manage_bank_holidays.py
@@ -1,11 +1,24 @@
 import sys
 import argparse
-from uk_election_timetables.bank_holidays import diff_bank_holidays, update_bank_holidays
+from uk_election_timetables.bank_holidays import (
+    diff_bank_holidays,
+    update_bank_holidays,
+)
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("-d", "--diff", action="store_true", help="Get number of additions in new .gov dataset")
-    parser.add_argument("-u", "--update", action="store_true", help="Update bank-holidays.json with .gov additions")
+    parser.add_argument(
+        "-d",
+        "--diff",
+        action="store_true",
+        help="Get number of additions in new .gov dataset",
+    )
+    parser.add_argument(
+        "-u",
+        "--update",
+        action="store_true",
+        help="Update bank-holidays.json with .gov additions",
+    )
     args = parser.parse_args()
 
     if args.diff:

--- a/manage_bank_holidays.py
+++ b/manage_bank_holidays.py
@@ -1,0 +1,25 @@
+import sys
+import argparse
+from uk_election_timetables.bank_holidays import diff_bank_holidays, update_bank_holidays
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-d", "--diff", action="store_true", help="Get number of additions in new .gov dataset")
+    parser.add_argument("-u", "--update", action="store_true", help="Update bank-holidays.json with .gov additions")
+    args = parser.parse_args()
+
+    if args.diff:
+        try:
+            additions_count: int = diff_bank_holidays()
+            sys.exit(additions_count)
+        except Exception as ex:
+            print(f"Unable to diff files")
+            sys.exit(0)
+    elif args.update:
+        try:
+            update_bank_holidays()
+            print("Update complete")
+        except Exception as ex:
+            print(f"Unable to update bank-holidays.json: {ex}")
+    else:
+        print("No action provided. Check --help for a list of actions.")

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ sphinx-markdown-tables==0.0.12
 pytest-cov==2.10.1
 coveralls==2.1.2
 six==1.15.0
+black==22.8.0

--- a/tests/data/bank_holidays.py
+++ b/tests/data/bank_holidays.py
@@ -2,69 +2,139 @@ base_data = {
     "england-and-wales": {
         "division": "england-and-wales",
         "events": [
-            {"title": "New Year’s Day", "date": "2021-01-01", "notes": "", "bunting": True},
-        ]
+            {
+                "title": "New Year’s Day",
+                "date": "2021-01-01",
+                "notes": "",
+                "bunting": True,
+            },
+        ],
     },
     "scotland": {
         "division": "scotland",
         "events": [
-            {"title": "New Year’s Day", "date": "2021-01-01", "notes": "", "bunting": True},
-        ]
+            {
+                "title": "New Year’s Day",
+                "date": "2021-01-01",
+                "notes": "",
+                "bunting": True,
+            },
+        ],
     },
     "northern-ireland": {
         "division": "northern-ireland",
         "events": [
-            {"title": "New Year’s Day", "date": "2021-01-01", "notes": "", "bunting": True},
-        ]
-    }
+            {
+                "title": "New Year’s Day",
+                "date": "2021-01-01",
+                "notes": "",
+                "bunting": True,
+            },
+        ],
+    },
 }
 
 single_new_event_per_division = {
     "england-and-wales": {
         "division": "england-and-wales",
         "events": [
-            {"title": "New Year’s Day", "date": "2021-01-01", "notes": "", "bunting": True},
+            {
+                "title": "New Year’s Day",
+                "date": "2021-01-01",
+                "notes": "",
+                "bunting": True,
+            },
             {"title": "Boxing Day", "date": "2022-12-26", "notes": "", "bunting": True},
-        ]
+        ],
     },
     "scotland": {
         "division": "scotland",
         "events": [
-            {"title": "New Year’s Day", "date": "2021-01-01", "notes": "", "bunting": True},
-            {"title": "New Year’s Day", "date": "2022-01-03", "notes": "Substitute day", "bunting": True},
-        ]
+            {
+                "title": "New Year’s Day",
+                "date": "2021-01-01",
+                "notes": "",
+                "bunting": True,
+            },
+            {
+                "title": "New Year’s Day",
+                "date": "2022-01-03",
+                "notes": "Substitute day",
+                "bunting": True,
+            },
+        ],
     },
     "northern-ireland": {
         "division": "northern-ireland",
         "events": [
-            {"title": "New Year’s Day", "date": "2021-01-01", "notes": "", "bunting": True},
-            {"title": "New Year’s Day", "date": "2022-01-03", "notes": "Substitute day", "bunting": True},
-        ]
-    }
+            {
+                "title": "New Year’s Day",
+                "date": "2021-01-01",
+                "notes": "",
+                "bunting": True,
+            },
+            {
+                "title": "New Year’s Day",
+                "date": "2022-01-03",
+                "notes": "Substitute day",
+                "bunting": True,
+            },
+        ],
+    },
 }
 
 single_historical_event_per_division = {
     "england-and-wales": {
         "division": "england-and-wales",
         "events": [
-            {"title": "Boxing Day", "date": "2020-12-28", "notes": "Substitute day", "bunting": True},
-            {"title": "New Year’s Day", "date": "2021-01-01", "notes": "", "bunting": True},
-        ]
+            {
+                "title": "Boxing Day",
+                "date": "2020-12-28",
+                "notes": "Substitute day",
+                "bunting": True,
+            },
+            {
+                "title": "New Year’s Day",
+                "date": "2021-01-01",
+                "notes": "",
+                "bunting": True,
+            },
+        ],
     },
     "scotland": {
         "division": "scotland",
         "events": [
-            {"title": "Boxing Day", "date": "2020-12-28", "notes": "Substitute day", "bunting": True},
-            {"title": "New Year’s Day", "date": "2021-01-01", "notes": "", "bunting": True},
-        ]
+            {
+                "title": "Boxing Day",
+                "date": "2020-12-28",
+                "notes": "Substitute day",
+                "bunting": True,
+            },
+            {
+                "title": "New Year’s Day",
+                "date": "2021-01-01",
+                "notes": "",
+                "bunting": True,
+            },
+        ],
     },
     "northern-ireland": {
         "division": "northern-ireland",
         "events": [
-            {"title": "Boxing Day", "date": "2020-12-28", "notes": "Substitute day", "bunting": True},
-            {"title": "New Year’s Day", "date": "2021-01-01", "notes": "", "bunting": True},
-        ]
-    }
+            {
+                "title": "Boxing Day",
+                "date": "2020-12-28",
+                "notes": "Substitute day",
+                "bunting": True,
+            },
+            {
+                "title": "New Year’s Day",
+                "date": "2021-01-01",
+                "notes": "",
+                "bunting": True,
+            },
+        ],
+    },
 }
 
 
@@ -72,67 +142,137 @@ changed_name = {
     "england-and-wales": {
         "division": "england-and-wales",
         "events": [
-            {"title": "New Year’s Day (England & Wales)", "date": "2021-01-01", "notes": "", "bunting": True},
-        ]
+            {
+                "title": "New Year’s Day (England & Wales)",
+                "date": "2021-01-01",
+                "notes": "",
+                "bunting": True,
+            },
+        ],
     },
     "scotland": {
         "division": "scotland",
         "events": [
-            {"title": "New Year’s Day (Scotland)", "date": "2021-01-01", "notes": "", "bunting": True},
-        ]
+            {
+                "title": "New Year’s Day (Scotland)",
+                "date": "2021-01-01",
+                "notes": "",
+                "bunting": True,
+            },
+        ],
     },
     "northern-ireland": {
         "division": "northern-ireland",
         "events": [
-            {"title": "New Year’s Day (Northern Ireland)", "date": "2021-01-01", "notes": "", "bunting": True},
-        ]
-    }
+            {
+                "title": "New Year’s Day (Northern Ireland)",
+                "date": "2021-01-01",
+                "notes": "",
+                "bunting": True,
+            },
+        ],
+    },
 }
 
 changed_name_and_date = {
     "england-and-wales": {
         "division": "england-and-wales",
         "events": [
-            {"title": "New Year’s Day (England & Wales)", "date": "2020-12-02", "notes": "", "bunting": True},
-        ]
+            {
+                "title": "New Year’s Day (England & Wales)",
+                "date": "2020-12-02",
+                "notes": "",
+                "bunting": True,
+            },
+        ],
     },
     "scotland": {
         "division": "scotland",
         "events": [
-            {"title": "New Year’s Day (Scotland)", "date": "2020-12-02", "notes": "", "bunting": True},
-        ]
+            {
+                "title": "New Year’s Day (Scotland)",
+                "date": "2020-12-02",
+                "notes": "",
+                "bunting": True,
+            },
+        ],
     },
     "northern-ireland": {
         "division": "northern-ireland",
         "events": [
-            {"title": "New Year’s Day (Northern Ireland)", "date": "2020-12-02", "notes": "", "bunting": True},
-        ]
-    }
+            {
+                "title": "New Year’s Day (Northern Ireland)",
+                "date": "2020-12-02",
+                "notes": "",
+                "bunting": True,
+            },
+        ],
+    },
 }
 
 complete_data = {
-    'england-and-wales':
-        {
-            'division': 'england-and-wales',
-            'events': [
-                {'title': 'Boxing Day', 'date': '2020-12-28', 'notes': 'Substitute day', 'bunting': True},
-                {'title': 'New Year’s Day', 'date': '2021-01-01', 'notes': '', 'bunting': True},
-                {'title': 'Boxing Day', 'date': '2022-12-26', 'notes': '', 'bunting': True}
-            ]
-        },
-    'scotland': {
-        'division': 'scotland',
-        'events': [
-            {'title': 'Boxing Day', 'date': '2020-12-28', 'notes': 'Substitute day', 'bunting': True},
-            {'title': 'New Year’s Day', 'date': '2021-01-01', 'notes': '', 'bunting': True},
-            {'title': 'New Year’s Day', 'date': '2022-01-03', 'notes': 'Substitute day', 'bunting': True}
-        ]},
-    'northern-ireland': {
-        'division': 'northern-ireland',
-        'events': [
-            {'title': 'Boxing Day', 'date': '2020-12-28', 'notes': 'Substitute day', 'bunting': True},
-            {'title': 'New Year’s Day', 'date': '2021-01-01', 'notes': '', 'bunting': True},
-            {'title': 'New Year’s Day', 'date': '2022-01-03', 'notes': 'Substitute day', 'bunting': True}
-        ]
-    }
+    "england-and-wales": {
+        "division": "england-and-wales",
+        "events": [
+            {
+                "title": "Boxing Day",
+                "date": "2020-12-28",
+                "notes": "Substitute day",
+                "bunting": True,
+            },
+            {
+                "title": "New Year’s Day",
+                "date": "2021-01-01",
+                "notes": "",
+                "bunting": True,
+            },
+            {"title": "Boxing Day", "date": "2022-12-26", "notes": "", "bunting": True},
+        ],
+    },
+    "scotland": {
+        "division": "scotland",
+        "events": [
+            {
+                "title": "Boxing Day",
+                "date": "2020-12-28",
+                "notes": "Substitute day",
+                "bunting": True,
+            },
+            {
+                "title": "New Year’s Day",
+                "date": "2021-01-01",
+                "notes": "",
+                "bunting": True,
+            },
+            {
+                "title": "New Year’s Day",
+                "date": "2022-01-03",
+                "notes": "Substitute day",
+                "bunting": True,
+            },
+        ],
+    },
+    "northern-ireland": {
+        "division": "northern-ireland",
+        "events": [
+            {
+                "title": "Boxing Day",
+                "date": "2020-12-28",
+                "notes": "Substitute day",
+                "bunting": True,
+            },
+            {
+                "title": "New Year’s Day",
+                "date": "2021-01-01",
+                "notes": "",
+                "bunting": True,
+            },
+            {
+                "title": "New Year’s Day",
+                "date": "2022-01-03",
+                "notes": "Substitute day",
+                "bunting": True,
+            },
+        ],
+    },
 }

--- a/tests/data/bank_holidays.py
+++ b/tests/data/bank_holidays.py
@@ -1,4 +1,4 @@
-existing_data = {
+base_data = {
     "england-and-wales": {
         "division": "england-and-wales",
         "events": [
@@ -63,6 +63,49 @@ single_historical_event_per_division = {
         "events": [
             {"title": "Boxing Day", "date": "2020-12-28", "notes": "Substitute day", "bunting": True},
             {"title": "New Year’s Day", "date": "2021-01-01", "notes": "", "bunting": True},
+        ]
+    }
+}
+
+
+changed_name = {
+    "england-and-wales": {
+        "division": "england-and-wales",
+        "events": [
+            {"title": "New Year’s Day (England & Wales)", "date": "2021-01-01", "notes": "", "bunting": True},
+        ]
+    },
+    "scotland": {
+        "division": "scotland",
+        "events": [
+            {"title": "New Year’s Day (Scotland)", "date": "2021-01-01", "notes": "", "bunting": True},
+        ]
+    },
+    "northern-ireland": {
+        "division": "northern-ireland",
+        "events": [
+            {"title": "New Year’s Day (Northern Ireland)", "date": "2021-01-01", "notes": "", "bunting": True},
+        ]
+    }
+}
+
+changed_name_and_date = {
+    "england-and-wales": {
+        "division": "england-and-wales",
+        "events": [
+            {"title": "New Year’s Day (England & Wales)", "date": "2020-12-02", "notes": "", "bunting": True},
+        ]
+    },
+    "scotland": {
+        "division": "scotland",
+        "events": [
+            {"title": "New Year’s Day (Scotland)", "date": "2020-12-02", "notes": "", "bunting": True},
+        ]
+    },
+    "northern-ireland": {
+        "division": "northern-ireland",
+        "events": [
+            {"title": "New Year’s Day (Northern Ireland)", "date": "2020-12-02", "notes": "", "bunting": True},
         ]
     }
 }

--- a/tests/data/bank_holidays.py
+++ b/tests/data/bank_holidays.py
@@ -3,42 +3,18 @@ existing_data = {
         "division": "england-and-wales",
         "events": [
             {"title": "New Year’s Day", "date": "2021-01-01", "notes": "", "bunting": True},
-            {"title": "Good Friday", "date": "2021-04-02", "notes": "", "bunting": False},
-            {"title": "Easter Monday", "date": "2021-04-05", "notes": "", "bunting": True},
-            {"title": "Early May bank holiday", "date": "2021-05-03", "notes": "", "bunting": True},
-            {"title": "Spring bank holiday", "date": "2021-05-31", "notes": "", "bunting": True},
-            {"title": "Summer bank holiday", "date": "2021-08-30", "notes": "", "bunting": True},
-            {"title": "Christmas Day", "date": "2021-12-27", "notes": "Substitute day", "bunting": True},
-            {"title": "Boxing Day", "date": "2021-12-28", "notes": "Substitute day", "bunting": True},
         ]
     },
     "scotland": {
         "division": "scotland",
         "events": [
             {"title": "New Year’s Day", "date": "2021-01-01", "notes": "", "bunting": True},
-            {"title": "2nd January", "date": "2021-01-04", "notes": "Substitute day", "bunting": True},
-            {"title": "Good Friday", "date": "2021-04-02", "notes": "", "bunting": False},
-            {"title": "Early May bank holiday", "date": "2021-05-03", "notes": "", "bunting": True},
-            {"title": "Spring bank holiday", "date": "2021-05-31", "notes": "", "bunting": True},
-            {"title": "Summer bank holiday", "date": "2021-08-02", "notes": "", "bunting": True},
-            {"title": "St Andrew’s Day", "date": "2021-11-30", "notes": "", "bunting": True},
-            {"title": "Christmas Day", "date": "2021-12-27", "notes": "Substitute day", "bunting": True},
-            {"title": "Boxing Day", "date": "2021-12-28", "notes": "Substitute day", "bunting": True}
         ]
     },
     "northern-ireland": {
         "division": "northern-ireland",
         "events": [
             {"title": "New Year’s Day", "date": "2021-01-01", "notes": "", "bunting": True},
-            {"title": "St Patrick’s Day", "date": "2021-03-17", "notes": "", "bunting": True},
-            {"title": "Good Friday", "date": "2021-04-02", "notes": "", "bunting": False},
-            {"title": "Easter Monday", "date": "2021-04-05", "notes": "", "bunting": True},
-            {"title": "Early May bank holiday", "date": "2021-05-03", "notes": "", "bunting": True},
-            {"title": "Spring bank holiday", "date": "2021-05-31", "notes": "", "bunting": True},
-            {"title": "Battle of the Boyne (Orangemen’s Day)", "date": "2021-07-12", "notes": "", "bunting": False},
-            {"title": "Summer bank holiday", "date": "2021-08-30", "notes": "", "bunting": True},
-            {"title": "Christmas Day", "date": "2021-12-27", "notes": "Substitute day", "bunting": True},
-            {"title": "Boxing Day", "date": "2021-12-28", "notes": "Substitute day", "bunting": True}
         ]
     }
 }
@@ -48,13 +24,6 @@ single_new_event_per_division = {
         "division": "england-and-wales",
         "events": [
             {"title": "New Year’s Day", "date": "2021-01-01", "notes": "", "bunting": True},
-            {"title": "Good Friday", "date": "2021-04-02", "notes": "", "bunting": False},
-            {"title": "Easter Monday", "date": "2021-04-05", "notes": "", "bunting": True},
-            {"title": "Early May bank holiday", "date": "2021-05-03", "notes": "", "bunting": True},
-            {"title": "Spring bank holiday", "date": "2021-05-31", "notes": "", "bunting": True},
-            {"title": "Summer bank holiday", "date": "2021-08-30", "notes": "", "bunting": True},
-            {"title": "Christmas Day", "date": "2021-12-27", "notes": "Substitute day", "bunting": True},
-            {"title": "Boxing Day", "date": "2021-12-28", "notes": "Substitute day", "bunting": True},
             {"title": "Boxing Day", "date": "2022-12-26", "notes": "", "bunting": True},
         ]
     },
@@ -62,14 +31,6 @@ single_new_event_per_division = {
         "division": "scotland",
         "events": [
             {"title": "New Year’s Day", "date": "2021-01-01", "notes": "", "bunting": True},
-            {"title": "2nd January", "date": "2021-01-04", "notes": "Substitute day", "bunting": True},
-            {"title": "Good Friday", "date": "2021-04-02", "notes": "", "bunting": False},
-            {"title": "Early May bank holiday", "date": "2021-05-03", "notes": "", "bunting": True},
-            {"title": "Spring bank holiday", "date": "2021-05-31", "notes": "", "bunting": True},
-            {"title": "Summer bank holiday", "date": "2021-08-02", "notes": "", "bunting": True},
-            {"title": "St Andrew’s Day", "date": "2021-11-30", "notes": "", "bunting": True},
-            {"title": "Christmas Day", "date": "2021-12-27", "notes": "Substitute day", "bunting": True},
-            {"title": "Boxing Day", "date": "2021-12-28", "notes": "Substitute day", "bunting": True},
             {"title": "New Year’s Day", "date": "2022-01-03", "notes": "Substitute day", "bunting": True},
         ]
     },
@@ -77,15 +38,6 @@ single_new_event_per_division = {
         "division": "northern-ireland",
         "events": [
             {"title": "New Year’s Day", "date": "2021-01-01", "notes": "", "bunting": True},
-            {"title": "St Patrick’s Day", "date": "2021-03-17", "notes": "", "bunting": True},
-            {"title": "Good Friday", "date": "2021-04-02", "notes": "", "bunting": False},
-            {"title": "Easter Monday", "date": "2021-04-05", "notes": "", "bunting": True},
-            {"title": "Early May bank holiday", "date": "2021-05-03", "notes": "", "bunting": True},
-            {"title": "Spring bank holiday", "date": "2021-05-31", "notes": "", "bunting": True},
-            {"title": "Battle of the Boyne (Orangemen’s Day)", "date": "2021-07-12", "notes": "", "bunting": False},
-            {"title": "Summer bank holiday", "date": "2021-08-30", "notes": "", "bunting": True},
-            {"title": "Christmas Day", "date": "2021-12-27", "notes": "Substitute day", "bunting": True},
-            {"title": "Boxing Day", "date": "2021-12-28", "notes": "Substitute day", "bunting": True},
             {"title": "New Year’s Day", "date": "2022-01-03", "notes": "Substitute day", "bunting": True},
         ]
     }
@@ -97,13 +49,6 @@ single_historical_event_per_division = {
         "events": [
             {"title": "Boxing Day", "date": "2020-12-28", "notes": "Substitute day", "bunting": True},
             {"title": "New Year’s Day", "date": "2021-01-01", "notes": "", "bunting": True},
-            {"title": "Good Friday", "date": "2021-04-02", "notes": "", "bunting": False},
-            {"title": "Easter Monday", "date": "2021-04-05", "notes": "", "bunting": True},
-            {"title": "Early May bank holiday", "date": "2021-05-03", "notes": "", "bunting": True},
-            {"title": "Spring bank holiday", "date": "2021-05-31", "notes": "", "bunting": True},
-            {"title": "Summer bank holiday", "date": "2021-08-30", "notes": "", "bunting": True},
-            {"title": "Christmas Day", "date": "2021-12-27", "notes": "Substitute day", "bunting": True},
-            {"title": "Boxing Day", "date": "2021-12-28", "notes": "Substitute day", "bunting": True},
         ]
     },
     "scotland": {
@@ -111,14 +56,6 @@ single_historical_event_per_division = {
         "events": [
             {"title": "Boxing Day", "date": "2020-12-28", "notes": "Substitute day", "bunting": True},
             {"title": "New Year’s Day", "date": "2021-01-01", "notes": "", "bunting": True},
-            {"title": "2nd January", "date": "2021-01-04", "notes": "Substitute day", "bunting": True},
-            {"title": "Good Friday", "date": "2021-04-02", "notes": "", "bunting": False},
-            {"title": "Early May bank holiday", "date": "2021-05-03", "notes": "", "bunting": True},
-            {"title": "Spring bank holiday", "date": "2021-05-31", "notes": "", "bunting": True},
-            {"title": "Summer bank holiday", "date": "2021-08-02", "notes": "", "bunting": True},
-            {"title": "St Andrew’s Day", "date": "2021-11-30", "notes": "", "bunting": True},
-            {"title": "Christmas Day", "date": "2021-12-27", "notes": "Substitute day", "bunting": True},
-            {"title": "Boxing Day", "date": "2021-12-28", "notes": "Substitute day", "bunting": True}
         ]
     },
     "northern-ireland": {
@@ -126,15 +63,33 @@ single_historical_event_per_division = {
         "events": [
             {"title": "Boxing Day", "date": "2020-12-28", "notes": "Substitute day", "bunting": True},
             {"title": "New Year’s Day", "date": "2021-01-01", "notes": "", "bunting": True},
-            {"title": "St Patrick’s Day", "date": "2021-03-17", "notes": "", "bunting": True},
-            {"title": "Good Friday", "date": "2021-04-02", "notes": "", "bunting": False},
-            {"title": "Easter Monday", "date": "2021-04-05", "notes": "", "bunting": True},
-            {"title": "Early May bank holiday", "date": "2021-05-03", "notes": "", "bunting": True},
-            {"title": "Spring bank holiday", "date": "2021-05-31", "notes": "", "bunting": True},
-            {"title": "Battle of the Boyne (Orangemen’s Day)", "date": "2021-07-12", "notes": "", "bunting": False},
-            {"title": "Summer bank holiday", "date": "2021-08-30", "notes": "", "bunting": True},
-            {"title": "Christmas Day", "date": "2021-12-27", "notes": "Substitute day", "bunting": True},
-            {"title": "Boxing Day", "date": "2021-12-28", "notes": "Substitute day", "bunting": True}
+        ]
+    }
+}
+
+complete_data = {
+    'england-and-wales':
+        {
+            'division': 'england-and-wales',
+            'events': [
+                {'title': 'Boxing Day', 'date': '2020-12-28', 'notes': 'Substitute day', 'bunting': True},
+                {'title': 'New Year’s Day', 'date': '2021-01-01', 'notes': '', 'bunting': True},
+                {'title': 'Boxing Day', 'date': '2022-12-26', 'notes': '', 'bunting': True}
+            ]
+        },
+    'scotland': {
+        'division': 'scotland',
+        'events': [
+            {'title': 'Boxing Day', 'date': '2020-12-28', 'notes': 'Substitute day', 'bunting': True},
+            {'title': 'New Year’s Day', 'date': '2021-01-01', 'notes': '', 'bunting': True},
+            {'title': 'New Year’s Day', 'date': '2022-01-03', 'notes': 'Substitute day', 'bunting': True}
+        ]},
+    'northern-ireland': {
+        'division': 'northern-ireland',
+        'events': [
+            {'title': 'Boxing Day', 'date': '2020-12-28', 'notes': 'Substitute day', 'bunting': True},
+            {'title': 'New Year’s Day', 'date': '2021-01-01', 'notes': '', 'bunting': True},
+            {'title': 'New Year’s Day', 'date': '2022-01-03', 'notes': 'Substitute day', 'bunting': True}
         ]
     }
 }

--- a/tests/data/bank_holidays.py
+++ b/tests/data/bank_holidays.py
@@ -1,0 +1,140 @@
+existing_data = {
+    "england-and-wales": {
+        "division": "england-and-wales",
+        "events": [
+            {"title": "New Year’s Day", "date": "2021-01-01", "notes": "", "bunting": True},
+            {"title": "Good Friday", "date": "2021-04-02", "notes": "", "bunting": False},
+            {"title": "Easter Monday", "date": "2021-04-05", "notes": "", "bunting": True},
+            {"title": "Early May bank holiday", "date": "2021-05-03", "notes": "", "bunting": True},
+            {"title": "Spring bank holiday", "date": "2021-05-31", "notes": "", "bunting": True},
+            {"title": "Summer bank holiday", "date": "2021-08-30", "notes": "", "bunting": True},
+            {"title": "Christmas Day", "date": "2021-12-27", "notes": "Substitute day", "bunting": True},
+            {"title": "Boxing Day", "date": "2021-12-28", "notes": "Substitute day", "bunting": True},
+        ]
+    },
+    "scotland": {
+        "division": "scotland",
+        "events": [
+            {"title": "New Year’s Day", "date": "2021-01-01", "notes": "", "bunting": True},
+            {"title": "2nd January", "date": "2021-01-04", "notes": "Substitute day", "bunting": True},
+            {"title": "Good Friday", "date": "2021-04-02", "notes": "", "bunting": False},
+            {"title": "Early May bank holiday", "date": "2021-05-03", "notes": "", "bunting": True},
+            {"title": "Spring bank holiday", "date": "2021-05-31", "notes": "", "bunting": True},
+            {"title": "Summer bank holiday", "date": "2021-08-02", "notes": "", "bunting": True},
+            {"title": "St Andrew’s Day", "date": "2021-11-30", "notes": "", "bunting": True},
+            {"title": "Christmas Day", "date": "2021-12-27", "notes": "Substitute day", "bunting": True},
+            {"title": "Boxing Day", "date": "2021-12-28", "notes": "Substitute day", "bunting": True}
+        ]
+    },
+    "northern-ireland": {
+        "division": "northern-ireland",
+        "events": [
+            {"title": "New Year’s Day", "date": "2021-01-01", "notes": "", "bunting": True},
+            {"title": "St Patrick’s Day", "date": "2021-03-17", "notes": "", "bunting": True},
+            {"title": "Good Friday", "date": "2021-04-02", "notes": "", "bunting": False},
+            {"title": "Easter Monday", "date": "2021-04-05", "notes": "", "bunting": True},
+            {"title": "Early May bank holiday", "date": "2021-05-03", "notes": "", "bunting": True},
+            {"title": "Spring bank holiday", "date": "2021-05-31", "notes": "", "bunting": True},
+            {"title": "Battle of the Boyne (Orangemen’s Day)", "date": "2021-07-12", "notes": "", "bunting": False},
+            {"title": "Summer bank holiday", "date": "2021-08-30", "notes": "", "bunting": True},
+            {"title": "Christmas Day", "date": "2021-12-27", "notes": "Substitute day", "bunting": True},
+            {"title": "Boxing Day", "date": "2021-12-28", "notes": "Substitute day", "bunting": True}
+        ]
+    }
+}
+
+single_new_event_per_division = {
+    "england-and-wales": {
+        "division": "england-and-wales",
+        "events": [
+            {"title": "New Year’s Day", "date": "2021-01-01", "notes": "", "bunting": True},
+            {"title": "Good Friday", "date": "2021-04-02", "notes": "", "bunting": False},
+            {"title": "Easter Monday", "date": "2021-04-05", "notes": "", "bunting": True},
+            {"title": "Early May bank holiday", "date": "2021-05-03", "notes": "", "bunting": True},
+            {"title": "Spring bank holiday", "date": "2021-05-31", "notes": "", "bunting": True},
+            {"title": "Summer bank holiday", "date": "2021-08-30", "notes": "", "bunting": True},
+            {"title": "Christmas Day", "date": "2021-12-27", "notes": "Substitute day", "bunting": True},
+            {"title": "Boxing Day", "date": "2021-12-28", "notes": "Substitute day", "bunting": True},
+            {"title": "Boxing Day", "date": "2022-12-26", "notes": "", "bunting": True},
+        ]
+    },
+    "scotland": {
+        "division": "scotland",
+        "events": [
+            {"title": "New Year’s Day", "date": "2021-01-01", "notes": "", "bunting": True},
+            {"title": "2nd January", "date": "2021-01-04", "notes": "Substitute day", "bunting": True},
+            {"title": "Good Friday", "date": "2021-04-02", "notes": "", "bunting": False},
+            {"title": "Early May bank holiday", "date": "2021-05-03", "notes": "", "bunting": True},
+            {"title": "Spring bank holiday", "date": "2021-05-31", "notes": "", "bunting": True},
+            {"title": "Summer bank holiday", "date": "2021-08-02", "notes": "", "bunting": True},
+            {"title": "St Andrew’s Day", "date": "2021-11-30", "notes": "", "bunting": True},
+            {"title": "Christmas Day", "date": "2021-12-27", "notes": "Substitute day", "bunting": True},
+            {"title": "Boxing Day", "date": "2021-12-28", "notes": "Substitute day", "bunting": True},
+            {"title": "New Year’s Day", "date": "2022-01-03", "notes": "Substitute day", "bunting": True},
+        ]
+    },
+    "northern-ireland": {
+        "division": "northern-ireland",
+        "events": [
+            {"title": "New Year’s Day", "date": "2021-01-01", "notes": "", "bunting": True},
+            {"title": "St Patrick’s Day", "date": "2021-03-17", "notes": "", "bunting": True},
+            {"title": "Good Friday", "date": "2021-04-02", "notes": "", "bunting": False},
+            {"title": "Easter Monday", "date": "2021-04-05", "notes": "", "bunting": True},
+            {"title": "Early May bank holiday", "date": "2021-05-03", "notes": "", "bunting": True},
+            {"title": "Spring bank holiday", "date": "2021-05-31", "notes": "", "bunting": True},
+            {"title": "Battle of the Boyne (Orangemen’s Day)", "date": "2021-07-12", "notes": "", "bunting": False},
+            {"title": "Summer bank holiday", "date": "2021-08-30", "notes": "", "bunting": True},
+            {"title": "Christmas Day", "date": "2021-12-27", "notes": "Substitute day", "bunting": True},
+            {"title": "Boxing Day", "date": "2021-12-28", "notes": "Substitute day", "bunting": True},
+            {"title": "New Year’s Day", "date": "2022-01-03", "notes": "Substitute day", "bunting": True},
+        ]
+    }
+}
+
+single_historical_event_per_division = {
+    "england-and-wales": {
+        "division": "england-and-wales",
+        "events": [
+            {"title": "Boxing Day", "date": "2020-12-28", "notes": "Substitute day", "bunting": True},
+            {"title": "New Year’s Day", "date": "2021-01-01", "notes": "", "bunting": True},
+            {"title": "Good Friday", "date": "2021-04-02", "notes": "", "bunting": False},
+            {"title": "Easter Monday", "date": "2021-04-05", "notes": "", "bunting": True},
+            {"title": "Early May bank holiday", "date": "2021-05-03", "notes": "", "bunting": True},
+            {"title": "Spring bank holiday", "date": "2021-05-31", "notes": "", "bunting": True},
+            {"title": "Summer bank holiday", "date": "2021-08-30", "notes": "", "bunting": True},
+            {"title": "Christmas Day", "date": "2021-12-27", "notes": "Substitute day", "bunting": True},
+            {"title": "Boxing Day", "date": "2021-12-28", "notes": "Substitute day", "bunting": True},
+        ]
+    },
+    "scotland": {
+        "division": "scotland",
+        "events": [
+            {"title": "Boxing Day", "date": "2020-12-28", "notes": "Substitute day", "bunting": True},
+            {"title": "New Year’s Day", "date": "2021-01-01", "notes": "", "bunting": True},
+            {"title": "2nd January", "date": "2021-01-04", "notes": "Substitute day", "bunting": True},
+            {"title": "Good Friday", "date": "2021-04-02", "notes": "", "bunting": False},
+            {"title": "Early May bank holiday", "date": "2021-05-03", "notes": "", "bunting": True},
+            {"title": "Spring bank holiday", "date": "2021-05-31", "notes": "", "bunting": True},
+            {"title": "Summer bank holiday", "date": "2021-08-02", "notes": "", "bunting": True},
+            {"title": "St Andrew’s Day", "date": "2021-11-30", "notes": "", "bunting": True},
+            {"title": "Christmas Day", "date": "2021-12-27", "notes": "Substitute day", "bunting": True},
+            {"title": "Boxing Day", "date": "2021-12-28", "notes": "Substitute day", "bunting": True}
+        ]
+    },
+    "northern-ireland": {
+        "division": "northern-ireland",
+        "events": [
+            {"title": "Boxing Day", "date": "2020-12-28", "notes": "Substitute day", "bunting": True},
+            {"title": "New Year’s Day", "date": "2021-01-01", "notes": "", "bunting": True},
+            {"title": "St Patrick’s Day", "date": "2021-03-17", "notes": "", "bunting": True},
+            {"title": "Good Friday", "date": "2021-04-02", "notes": "", "bunting": False},
+            {"title": "Easter Monday", "date": "2021-04-05", "notes": "", "bunting": True},
+            {"title": "Early May bank holiday", "date": "2021-05-03", "notes": "", "bunting": True},
+            {"title": "Spring bank holiday", "date": "2021-05-31", "notes": "", "bunting": True},
+            {"title": "Battle of the Boyne (Orangemen’s Day)", "date": "2021-07-12", "notes": "", "bunting": False},
+            {"title": "Summer bank holiday", "date": "2021-08-30", "notes": "", "bunting": True},
+            {"title": "Christmas Day", "date": "2021-12-27", "notes": "Substitute day", "bunting": True},
+            {"title": "Boxing Day", "date": "2021-12-28", "notes": "Substitute day", "bunting": True}
+        ]
+    }
+}

--- a/tests/test_bank_holidays.py
+++ b/tests/test_bank_holidays.py
@@ -1,0 +1,21 @@
+import pytest
+from typing import Dict
+from .data.bank_holidays import (
+    existing_data as seed_data,
+    single_new_event_per_division as gov_data,
+    single_historical_event_per_division as historical_data
+)
+from uk_election_timetables.bank_holidays import get_additions_count
+
+@pytest.mark.parametrize(
+    "existing_dataset, new_dataset, expected_count",
+    [
+        (seed_data, gov_data, 3),  # New events from .gov recognised as changes
+        (historical_data, seed_data, 0),  # Historical events aren't recognised as changes
+        (seed_data, seed_data, 0),  # Identical datasets not recognised as changes
+        ({}, {}, 0)  # Improperly formatted datasets
+    ]
+)
+def test_get_additions_count(existing_dataset: Dict, new_dataset: Dict, expected_count: int):
+    diff = get_additions_count(existing_dataset, new_dataset)
+    assert diff == expected_count

--- a/tests/test_bank_holidays.py
+++ b/tests/test_bank_holidays.py
@@ -1,33 +1,42 @@
+import copy
 import pytest
 from typing import Dict
 from .data.bank_holidays import (
-    existing_data as seed_data,
+    base_data,
     single_new_event_per_division as gov_data,
     single_historical_event_per_division as historical_data,
+    changed_name,
+    changed_name_and_date,
     complete_data
 )
 from uk_election_timetables.bank_holidays import get_additions_count, combine_bank_holiday_lists
 
+
 @pytest.mark.parametrize(
     "existing_dataset, new_dataset, expected_count",
     [
-        (seed_data, gov_data, 3),  # New events from .gov recognised as changes
-        (historical_data, seed_data, 0),  # Historical events in our dataset aren't recognised as changes
-        (seed_data, seed_data, 0),  # Identical datasets not recognised as changes
+        (base_data, gov_data, 3),  # New events from .gov recognised as changes
+        (historical_data, base_data, 0),  # Historical events in our dataset aren't recognised as changes
+        (base_data, base_data, 0),  # Identical datasets not recognised as changes
         ({}, {}, 0)  # Improperly formatted datasets
     ]
 )
 def test_get_additions_count(existing_dataset: Dict, new_dataset: Dict, expected_count: int):
-    diff = get_additions_count(existing_dataset, new_dataset)
+    diff: int = get_additions_count(existing_dataset, new_dataset)
     assert diff == expected_count
+
 
 @pytest.mark.parametrize(
     "existing_dataset, new_dataset, expected_result",
     [
         (historical_data, gov_data, complete_data),  # All the old and new data combined
-        (historical_data, historical_data, historical_data)  # No changes
+        (historical_data, historical_data, historical_data),  # No changes
+        (base_data, changed_name, changed_name),  # Change to event name only
+        (base_data, changed_name_and_date, changed_name_and_date)  # Change to event date and name
     ]
 )
-def test_combine_bank_holiday_lists(existing_dataset, new_dataset, expected_result):
-    new_dict = combine_bank_holiday_lists(existing_dataset, new_dataset)
-    assert new_dict == complete_data
+def test_combine_bank_holiday_lists(existing_dataset: Dict, new_dataset: Dict, expected_result: Dict):
+    existing_dataset_copy: Dict = copy.deepcopy(existing_dataset)
+    new_dataset_copy: Dict = copy.deepcopy(new_dataset)
+    new_dict: Dict = combine_bank_holiday_lists(existing_dataset_copy, new_dataset_copy)
+    assert new_dict == expected_result

--- a/tests/test_bank_holidays.py
+++ b/tests/test_bank_holidays.py
@@ -7,21 +7,30 @@ from .data.bank_holidays import (
     single_historical_event_per_division as historical_data,
     changed_name,
     changed_name_and_date,
-    complete_data
+    complete_data,
 )
-from uk_election_timetables.bank_holidays import get_additions_count, combine_bank_holiday_lists
+from uk_election_timetables.bank_holidays import (
+    get_additions_count,
+    combine_bank_holiday_lists,
+)
 
 
 @pytest.mark.parametrize(
     "existing_dataset, new_dataset, expected_count",
     [
         (base_data, gov_data, 3),  # New events from .gov recognised as changes
-        (historical_data, base_data, 0),  # Historical events in our dataset aren't recognised as changes
+        (
+            historical_data,
+            base_data,
+            0,
+        ),  # Historical events in our dataset aren't recognised as changes
         (base_data, base_data, 0),  # Identical datasets not recognised as changes
-        ({}, {}, 0)  # Improperly formatted datasets
-    ]
+        ({}, {}, 0),  # Improperly formatted datasets
+    ],
 )
-def test_get_additions_count(existing_dataset: Dict, new_dataset: Dict, expected_count: int):
+def test_get_additions_count(
+    existing_dataset: Dict, new_dataset: Dict, expected_count: int
+):
     diff: int = get_additions_count(existing_dataset, new_dataset)
     assert diff == expected_count
 
@@ -32,10 +41,16 @@ def test_get_additions_count(existing_dataset: Dict, new_dataset: Dict, expected
         (historical_data, gov_data, complete_data),  # All the old and new data combined
         (historical_data, historical_data, historical_data),  # No changes
         (base_data, changed_name, changed_name),  # Change to event name only
-        (base_data, changed_name_and_date, changed_name_and_date)  # Change to event date and name
-    ]
+        (
+            base_data,
+            changed_name_and_date,
+            changed_name_and_date,
+        ),  # Change to event date and name
+    ],
 )
-def test_combine_bank_holiday_lists(existing_dataset: Dict, new_dataset: Dict, expected_result: Dict):
+def test_combine_bank_holiday_lists(
+    existing_dataset: Dict, new_dataset: Dict, expected_result: Dict
+):
     existing_dataset_copy: Dict = copy.deepcopy(existing_dataset)
     new_dataset_copy: Dict = copy.deepcopy(new_dataset)
     new_dict: Dict = combine_bank_holiday_lists(existing_dataset_copy, new_dataset_copy)

--- a/tests/test_bank_holidays.py
+++ b/tests/test_bank_holidays.py
@@ -3,15 +3,16 @@ from typing import Dict
 from .data.bank_holidays import (
     existing_data as seed_data,
     single_new_event_per_division as gov_data,
-    single_historical_event_per_division as historical_data
+    single_historical_event_per_division as historical_data,
+    complete_data
 )
-from uk_election_timetables.bank_holidays import get_additions_count
+from uk_election_timetables.bank_holidays import get_additions_count, combine_bank_holiday_lists
 
 @pytest.mark.parametrize(
     "existing_dataset, new_dataset, expected_count",
     [
         (seed_data, gov_data, 3),  # New events from .gov recognised as changes
-        (historical_data, seed_data, 0),  # Historical events aren't recognised as changes
+        (historical_data, seed_data, 0),  # Historical events in our dataset aren't recognised as changes
         (seed_data, seed_data, 0),  # Identical datasets not recognised as changes
         ({}, {}, 0)  # Improperly formatted datasets
     ]
@@ -19,3 +20,14 @@ from uk_election_timetables.bank_holidays import get_additions_count
 def test_get_additions_count(existing_dataset: Dict, new_dataset: Dict, expected_count: int):
     diff = get_additions_count(existing_dataset, new_dataset)
     assert diff == expected_count
+
+@pytest.mark.parametrize(
+    "existing_dataset, new_dataset, expected_result",
+    [
+        (historical_data, gov_data, complete_data),  # All the old and new data combined
+        (historical_data, historical_data, historical_data)  # No changes
+    ]
+)
+def test_combine_bank_holiday_lists(existing_dataset, new_dataset, expected_result):
+    new_dict = combine_bank_holiday_lists(existing_dataset, new_dataset)
+    assert new_dict == complete_data

--- a/uk_election_timetables/bank-holidays.json
+++ b/uk_election_timetables/bank-holidays.json
@@ -1,1 +1,2027 @@
-{"england-and-wales":{"division":"england-and-wales","events":[{"title":"New Year’s Day","date":"2016-01-01","notes":"","bunting":true},{"title":"Good Friday","date":"2016-03-25","notes":"","bunting":false},{"title":"Easter Monday","date":"2016-03-28","notes":"","bunting":true},{"title":"Early May bank holiday","date":"2016-05-02","notes":"","bunting":true},{"title":"Spring bank holiday","date":"2016-05-30","notes":"","bunting":true},{"title":"Summer bank holiday","date":"2016-08-29","notes":"","bunting":true},{"title":"Boxing Day","date":"2016-12-26","notes":"","bunting":true},{"title":"Christmas Day","date":"2016-12-27","notes":"Substitute day","bunting":true},{"title":"New Year’s Day","date":"2017-01-02","notes":"Substitute day","bunting":true},{"title":"Good Friday","date":"2017-04-14","notes":"","bunting":false},{"title":"Easter Monday","date":"2017-04-17","notes":"","bunting":true},{"title":"Early May bank holiday","date":"2017-05-01","notes":"","bunting":true},{"title":"Spring bank holiday","date":"2017-05-29","notes":"","bunting":true},{"title":"Summer bank holiday","date":"2017-08-28","notes":"","bunting":true},{"title":"Christmas Day","date":"2017-12-25","notes":"","bunting":true},{"title":"Boxing Day","date":"2017-12-26","notes":"","bunting":true},{"title":"New Year’s Day","date":"2018-01-01","notes":"","bunting":true},{"title":"Good Friday","date":"2018-03-30","notes":"","bunting":false},{"title":"Easter Monday","date":"2018-04-02","notes":"","bunting":true},{"title":"Early May bank holiday","date":"2018-05-07","notes":"","bunting":true},{"title":"Spring bank holiday","date":"2018-05-28","notes":"","bunting":true},{"title":"Summer bank holiday","date":"2018-08-27","notes":"","bunting":true},{"title":"Christmas Day","date":"2018-12-25","notes":"","bunting":true},{"title":"Boxing Day","date":"2018-12-26","notes":"","bunting":true},{"title":"New Year’s Day","date":"2019-01-01","notes":"","bunting":true},{"title":"Good Friday","date":"2019-04-19","notes":"","bunting":false},{"title":"Easter Monday","date":"2019-04-22","notes":"","bunting":true},{"title":"Early May bank holiday","date":"2019-05-06","notes":"","bunting":true},{"title":"Spring bank holiday","date":"2019-05-27","notes":"","bunting":true},{"title":"Summer bank holiday","date":"2019-08-26","notes":"","bunting":true},{"title":"Christmas Day","date":"2019-12-25","notes":"","bunting":true},{"title":"Boxing Day","date":"2019-12-26","notes":"","bunting":true},{"title":"New Year’s Day","date":"2020-01-01","notes":"","bunting":true},{"title":"Good Friday","date":"2020-04-10","notes":"","bunting":false},{"title":"Easter Monday","date":"2020-04-13","notes":"","bunting":false},{"title":"Early May bank holiday (VE day)","date":"2020-05-08","notes":"","bunting":true},{"title":"Spring bank holiday","date":"2020-05-25","notes":"","bunting":true},{"title":"Summer bank holiday","date":"2020-08-31","notes":"","bunting":true},{"title":"Christmas Day","date":"2020-12-25","notes":"","bunting":true},{"title":"Boxing Day","date":"2020-12-28","notes":"Substitute day","bunting":true},{"title":"New Year’s Day","date":"2021-01-01","notes":"","bunting":true},{"title":"Good Friday","date":"2021-04-02","notes":"","bunting":false},{"title":"Easter Monday","date":"2021-04-05","notes":"","bunting":true},{"title":"Early May bank holiday","date":"2021-05-03","notes":"","bunting":true},{"title":"Spring bank holiday","date":"2021-05-31","notes":"","bunting":true},{"title":"Summer bank holiday","date":"2021-08-30","notes":"","bunting":true},{"title":"Christmas Day","date":"2021-12-27","notes":"Substitute day","bunting":true},{"title":"Boxing Day","date":"2021-12-28","notes":"Substitute day","bunting":true},{"title":"New Year’s Day","date":"2022-01-03","notes":"Substitute day","bunting":true},{"title":"Good Friday","date":"2022-04-15","notes":"","bunting":false},{"title":"Easter Monday","date":"2022-04-18","notes":"","bunting":true},{"title":"Early May bank holiday","date":"2022-05-02","notes":"","bunting":true},{"title":"Spring bank holiday","date":"2022-06-02","notes":"","bunting":true},{"title":"Platinum Jubilee bank holiday","date":"2022-06-03","notes":"","bunting":true},{"title":"Summer bank holiday","date":"2022-08-29","notes":"","bunting":true},{"title":"Bank Holiday for the State Funeral of Queen Elizabeth II","date":"2022-09-19","notes":"","bunting":false},{"title":"Boxing Day","date":"2022-12-26","notes":"","bunting":true},{"title":"Christmas Day","date":"2022-12-27","notes":"Substitute day","bunting":true},{"title":"New Year’s Day","date":"2023-01-02","notes":"Substitute day","bunting":true},{"title":"Good Friday","date":"2023-04-07","notes":"","bunting":false},{"title":"Easter Monday","date":"2023-04-10","notes":"","bunting":true},{"title":"Early May bank holiday","date":"2023-05-01","notes":"","bunting":true},{"title":"Spring bank holiday","date":"2023-05-29","notes":"","bunting":true},{"title":"Summer bank holiday","date":"2023-08-28","notes":"","bunting":true},{"title":"Christmas Day","date":"2023-12-25","notes":"","bunting":true},{"title":"Boxing Day","date":"2023-12-26","notes":"","bunting":true}]},"scotland":{"division":"scotland","events":[{"title":"New Year’s Day","date":"2016-01-01","notes":"","bunting":true},{"title":"2nd January","date":"2016-01-04","notes":"Substitute day","bunting":true},{"title":"Good Friday","date":"2016-03-25","notes":"","bunting":false},{"title":"Early May bank holiday","date":"2016-05-02","notes":"","bunting":true},{"title":"Spring bank holiday","date":"2016-05-30","notes":"","bunting":true},{"title":"Summer bank holiday","date":"2016-08-01","notes":"","bunting":true},{"title":"St Andrew’s Day","date":"2016-11-30","notes":"","bunting":true},{"title":"Boxing Day","date":"2016-12-26","notes":"","bunting":true},{"title":"Christmas Day","date":"2016-12-27","notes":"Substitute day","bunting":true},{"title":"2nd January","date":"2017-01-02","notes":"","bunting":true},{"title":"New Year’s Day","date":"2017-01-03","notes":"Substitute day","bunting":true},{"title":"Good Friday","date":"2017-04-14","notes":"","bunting":false},{"title":"Early May bank holiday","date":"2017-05-01","notes":"","bunting":true},{"title":"Spring bank holiday","date":"2017-05-29","notes":"","bunting":true},{"title":"Summer bank holiday","date":"2017-08-07","notes":"","bunting":true},{"title":"St Andrew’s Day","date":"2017-11-30","notes":"","bunting":true},{"title":"Christmas Day","date":"2017-12-25","notes":"","bunting":true},{"title":"Boxing Day","date":"2017-12-26","notes":"","bunting":true},{"title":"New Year’s Day","date":"2018-01-01","notes":"","bunting":true},{"title":"2nd January","date":"2018-01-02","notes":"","bunting":true},{"title":"Good Friday","date":"2018-03-30","notes":"","bunting":false},{"title":"Early May bank holiday","date":"2018-05-07","notes":"","bunting":true},{"title":"Spring bank holiday","date":"2018-05-28","notes":"","bunting":true},{"title":"Summer bank holiday","date":"2018-08-06","notes":"","bunting":true},{"title":"St Andrew’s Day","date":"2018-11-30","notes":"","bunting":true},{"title":"Christmas Day","date":"2018-12-25","notes":"","bunting":true},{"title":"Boxing Day","date":"2018-12-26","notes":"","bunting":true},{"title":"New Year’s Day","date":"2019-01-01","notes":"","bunting":true},{"title":"2nd January","date":"2019-01-02","notes":"","bunting":true},{"title":"Good Friday","date":"2019-04-19","notes":"","bunting":false},{"title":"Early May bank holiday","date":"2019-05-06","notes":"","bunting":true},{"title":"Spring bank holiday","date":"2019-05-27","notes":"","bunting":true},{"title":"Summer bank holiday","date":"2019-08-05","notes":"","bunting":true},{"title":"St Andrew’s Day","date":"2019-12-02","notes":"Substitute day","bunting":true},{"title":"Christmas Day","date":"2019-12-25","notes":"","bunting":true},{"title":"Boxing Day","date":"2019-12-26","notes":"","bunting":true},{"title":"New Year’s Day","date":"2020-01-01","notes":"","bunting":true},{"title":"2nd January","date":"2020-01-02","notes":"","bunting":true},{"title":"Good Friday","date":"2020-04-10","notes":"","bunting":false},{"title":"Early May bank holiday (VE day)","date":"2020-05-08","notes":"","bunting":true},{"title":"Spring bank holiday","date":"2020-05-25","notes":"","bunting":true},{"title":"Summer bank holiday","date":"2020-08-03","notes":"","bunting":true},{"title":"St Andrew’s Day","date":"2020-11-30","notes":"","bunting":true},{"title":"Christmas Day","date":"2020-12-25","notes":"","bunting":true},{"title":"Boxing Day","date":"2020-12-28","notes":"Substitute day","bunting":true},{"title":"New Year’s Day","date":"2021-01-01","notes":"","bunting":true},{"title":"2nd January","date":"2021-01-04","notes":"Substitute day","bunting":true},{"title":"Good Friday","date":"2021-04-02","notes":"","bunting":false},{"title":"Early May bank holiday","date":"2021-05-03","notes":"","bunting":true},{"title":"Spring bank holiday","date":"2021-05-31","notes":"","bunting":true},{"title":"Summer bank holiday","date":"2021-08-02","notes":"","bunting":true},{"title":"St Andrew’s Day","date":"2021-11-30","notes":"","bunting":true},{"title":"Christmas Day","date":"2021-12-27","notes":"Substitute day","bunting":true},{"title":"Boxing Day","date":"2021-12-28","notes":"Substitute day","bunting":true},{"title":"New Year’s Day","date":"2022-01-03","notes":"Substitute day","bunting":true},{"title":"2nd January","date":"2022-01-04","notes":"Substitute day","bunting":true},{"title":"Good Friday","date":"2022-04-15","notes":"","bunting":false},{"title":"Early May bank holiday","date":"2022-05-02","notes":"","bunting":true},{"title":"Spring bank holiday","date":"2022-06-02","notes":"","bunting":true},{"title":"Platinum Jubilee bank holiday","date":"2022-06-03","notes":"","bunting":true},{"title":"Summer bank holiday","date":"2022-08-01","notes":"","bunting":true},{"title":"Bank Holiday for the State Funeral of Queen Elizabeth II","date":"2022-09-19","notes":"","bunting":false},{"title":"St Andrew’s Day","date":"2022-11-30","notes":"","bunting":true},{"title":"Boxing Day","date":"2022-12-26","notes":"","bunting":true},{"title":"Christmas Day","date":"2022-12-27","notes":"Substitute day","bunting":true},{"title":"New Year’s Day","date":"2023-01-02","notes":"Substitute day","bunting":true},{"title":"2nd January","date":"2023-01-03","notes":"Substitute day","bunting":true},{"title":"Good Friday","date":"2023-04-07","notes":"","bunting":false},{"title":"Early May bank holiday","date":"2023-05-01","notes":"","bunting":true},{"title":"Spring bank holiday","date":"2023-05-29","notes":"","bunting":true},{"title":"Summer bank holiday","date":"2023-08-07","notes":"","bunting":true},{"title":"St Andrew’s Day","date":"2023-11-30","notes":"","bunting":true},{"title":"Christmas Day","date":"2023-12-25","notes":"","bunting":true},{"title":"Boxing Day","date":"2023-12-26","notes":"","bunting":true}]},"northern-ireland":{"division":"northern-ireland","events":[{"title":"New Year’s Day","date":"2016-01-01","notes":"","bunting":true},{"title":"St Patrick’s Day","date":"2016-03-17","notes":"","bunting":true},{"title":"Good Friday","date":"2016-03-25","notes":"","bunting":false},{"title":"Easter Monday","date":"2016-03-28","notes":"","bunting":true},{"title":"Early May bank holiday","date":"2016-05-02","notes":"","bunting":true},{"title":"Spring bank holiday","date":"2016-05-30","notes":"","bunting":true},{"title":"Battle of the Boyne (Orangemen’s Day)","date":"2016-07-12","notes":"","bunting":false},{"title":"Summer bank holiday","date":"2016-08-29","notes":"","bunting":true},{"title":"Boxing Day","date":"2016-12-26","notes":"","bunting":true},{"title":"Christmas Day","date":"2016-12-27","notes":"Substitute day","bunting":true},{"title":"New Year’s Day","date":"2017-01-02","notes":"Substitute day","bunting":true},{"title":"St Patrick’s Day","date":"2017-03-17","notes":"","bunting":true},{"title":"Good Friday","date":"2017-04-14","notes":"","bunting":false},{"title":"Easter Monday","date":"2017-04-17","notes":"","bunting":true},{"title":"Early May bank holiday","date":"2017-05-01","notes":"","bunting":true},{"title":"Spring bank holiday","date":"2017-05-29","notes":"","bunting":true},{"title":"Battle of the Boyne (Orangemen’s Day)","date":"2017-07-12","notes":"","bunting":false},{"title":"Summer bank holiday","date":"2017-08-28","notes":"","bunting":true},{"title":"Christmas Day","date":"2017-12-25","notes":"","bunting":true},{"title":"Boxing Day","date":"2017-12-26","notes":"","bunting":true},{"title":"New Year’s Day","date":"2018-01-01","notes":"","bunting":true},{"title":"St Patrick’s Day","date":"2018-03-19","notes":"Substitute day","bunting":true},{"title":"Good Friday","date":"2018-03-30","notes":"","bunting":false},{"title":"Easter Monday","date":"2018-04-02","notes":"","bunting":true},{"title":"Early May bank holiday","date":"2018-05-07","notes":"","bunting":true},{"title":"Spring bank holiday","date":"2018-05-28","notes":"","bunting":true},{"title":"Battle of the Boyne (Orangemen’s Day)","date":"2018-07-12","notes":"","bunting":false},{"title":"Summer bank holiday","date":"2018-08-27","notes":"","bunting":true},{"title":"Christmas Day","date":"2018-12-25","notes":"","bunting":true},{"title":"Boxing Day","date":"2018-12-26","notes":"","bunting":true},{"title":"New Year’s Day","date":"2019-01-01","notes":"","bunting":true},{"title":"St Patrick’s Day","date":"2019-03-18","notes":"Substitute day","bunting":true},{"title":"Good Friday","date":"2019-04-19","notes":"","bunting":false},{"title":"Easter Monday","date":"2019-04-22","notes":"","bunting":true},{"title":"Early May bank holiday","date":"2019-05-06","notes":"","bunting":true},{"title":"Spring bank holiday","date":"2019-05-27","notes":"","bunting":true},{"title":"Battle of the Boyne (Orangemen’s Day)","date":"2019-07-12","notes":"","bunting":false},{"title":"Summer bank holiday","date":"2019-08-26","notes":"","bunting":true},{"title":"Christmas Day","date":"2019-12-25","notes":"","bunting":true},{"title":"Boxing Day","date":"2019-12-26","notes":"","bunting":true},{"title":"New Year’s Day","date":"2020-01-01","notes":"","bunting":true},{"title":"St Patrick’s Day","date":"2020-03-17","notes":"","bunting":true},{"title":"Good Friday","date":"2020-04-10","notes":"","bunting":false},{"title":"Easter Monday","date":"2020-04-13","notes":"","bunting":false},{"title":"Early May bank holiday (VE day)","date":"2020-05-08","notes":"","bunting":true},{"title":"Spring bank holiday","date":"2020-05-25","notes":"","bunting":true},{"title":"Battle of the Boyne (Orangemen’s Day)","date":"2020-07-13","notes":"Substitute day","bunting":false},{"title":"Summer bank holiday","date":"2020-08-31","notes":"","bunting":true},{"title":"Christmas Day","date":"2020-12-25","notes":"","bunting":true},{"title":"Boxing Day","date":"2020-12-28","notes":"Substitute day","bunting":true},{"title":"New Year’s Day","date":"2021-01-01","notes":"","bunting":true},{"title":"St Patrick’s Day","date":"2021-03-17","notes":"","bunting":true},{"title":"Good Friday","date":"2021-04-02","notes":"","bunting":false},{"title":"Easter Monday","date":"2021-04-05","notes":"","bunting":true},{"title":"Early May bank holiday","date":"2021-05-03","notes":"","bunting":true},{"title":"Spring bank holiday","date":"2021-05-31","notes":"","bunting":true},{"title":"Battle of the Boyne (Orangemen’s Day)","date":"2021-07-12","notes":"","bunting":false},{"title":"Summer bank holiday","date":"2021-08-30","notes":"","bunting":true},{"title":"Christmas Day","date":"2021-12-27","notes":"Substitute day","bunting":true},{"title":"Boxing Day","date":"2021-12-28","notes":"Substitute day","bunting":true},{"title":"New Year’s Day","date":"2022-01-03","notes":"Substitute day","bunting":true},{"title":"St Patrick’s Day","date":"2022-03-17","notes":"","bunting":true},{"title":"Good Friday","date":"2022-04-15","notes":"","bunting":false},{"title":"Easter Monday","date":"2022-04-18","notes":"","bunting":true},{"title":"Early May bank holiday","date":"2022-05-02","notes":"","bunting":true},{"title":"Spring bank holiday","date":"2022-06-02","notes":"","bunting":true},{"title":"Platinum Jubilee bank holiday","date":"2022-06-03","notes":"","bunting":true},{"title":"Battle of the Boyne (Orangemen’s Day)","date":"2022-07-12","notes":"","bunting":false},{"title":"Summer bank holiday","date":"2022-08-29","notes":"","bunting":true},{"title":"Bank Holiday for the State Funeral of Queen Elizabeth II","date":"2022-09-19","notes":"","bunting":false},{"title":"Boxing Day","date":"2022-12-26","notes":"","bunting":true},{"title":"Christmas Day","date":"2022-12-27","notes":"Substitute day","bunting":true},{"title":"New Year’s Day","date":"2023-01-02","notes":"Substitute day","bunting":true},{"title":"St Patrick’s Day","date":"2023-03-17","notes":"","bunting":true},{"title":"Good Friday","date":"2023-04-07","notes":"","bunting":false},{"title":"Easter Monday","date":"2023-04-10","notes":"","bunting":true},{"title":"Early May bank holiday","date":"2023-05-01","notes":"","bunting":true},{"title":"Spring bank holiday","date":"2023-05-29","notes":"","bunting":true},{"title":"Battle of the Boyne (Orangemen’s Day)","date":"2023-07-12","notes":"","bunting":false},{"title":"Summer bank holiday","date":"2023-08-28","notes":"","bunting":true},{"title":"Christmas Day","date":"2023-12-25","notes":"","bunting":true},{"title":"Boxing Day","date":"2023-12-26","notes":"","bunting":true}]}}
+{
+    "england-and-wales": {
+        "division": "england-and-wales",
+        "events": [
+            {
+                "title": "New Year's Day",
+                "date": "2012-01-02",
+                "notes": "Substitute day",
+                "bunting": true
+            },
+            {
+                "title": "Good Friday",
+                "date": "2012-04-06",
+                "notes": "",
+                "bunting": false
+            },
+            {
+                "title": "Easter Monday",
+                "date": "2012-04-09",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Early May bank holiday",
+                "date": "2012-05-07",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Spring bank holiday",
+                "date": "2012-06-04",
+                "notes": "Substitute day",
+                "bunting": true
+            },
+            {
+                "title": "Queen's Diamond Jubilee",
+                "date": "2012-06-05",
+                "notes": "Extra bank holiday",
+                "bunting": true
+            },
+            {
+                "title": "Summer bank holiday",
+                "date": "2012-08-27",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Christmas Day",
+                "date": "2012-12-25",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Boxing Day",
+                "date": "2012-12-26",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "New Year's Day",
+                "date": "2013-01-01",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Good Friday",
+                "date": "2013-03-29",
+                "notes": "",
+                "bunting": false
+            },
+            {
+                "title": "Easter Monday",
+                "date": "2013-04-01",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Early May bank holiday",
+                "date": "2013-05-06",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Spring bank holiday",
+                "date": "2013-05-27",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Summer bank holiday",
+                "date": "2013-08-26",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Christmas Day",
+                "date": "2013-12-25",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Boxing Day",
+                "date": "2013-12-26",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "New Year's Day",
+                "date": "2014-01-01",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Good Friday",
+                "date": "2014-04-18",
+                "notes": "",
+                "bunting": false
+            },
+            {
+                "title": "Easter Monday",
+                "date": "2014-04-21",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Early May bank holiday",
+                "date": "2014-05-05",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Spring bank holiday",
+                "date": "2014-05-26",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Summer bank holiday",
+                "date": "2014-08-25",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Christmas Day",
+                "date": "2014-12-25",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Boxing Day",
+                "date": "2014-12-26",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "New Year's Day",
+                "date": "2015-01-01",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Good Friday",
+                "date": "2015-04-03",
+                "notes": "",
+                "bunting": false
+            },
+            {
+                "title": "Easter Monday",
+                "date": "2015-04-06",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Early May bank holiday",
+                "date": "2015-05-04",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Spring bank holiday",
+                "date": "2015-05-25",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Summer bank holiday",
+                "date": "2015-08-31",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Christmas Day",
+                "date": "2015-12-25",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Boxing Day",
+                "date": "2015-12-28",
+                "notes": "Substitute day",
+                "bunting": true
+            },
+            {
+                "title": "New Year's Day",
+                "date": "2016-01-01",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Good Friday",
+                "date": "2016-03-25",
+                "notes": "",
+                "bunting": false
+            },
+            {
+                "title": "Easter Monday",
+                "date": "2016-03-28",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Early May bank holiday",
+                "date": "2016-05-02",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Spring bank holiday",
+                "date": "2016-05-30",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Summer bank holiday",
+                "date": "2016-08-29",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Boxing Day",
+                "date": "2016-12-26",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Christmas Day",
+                "date": "2016-12-27",
+                "notes": "Substitute day",
+                "bunting": true
+            },
+            {
+                "title": "New Year's Day",
+                "date": "2017-01-02",
+                "notes": "Substitute day",
+                "bunting": true
+            },
+            {
+                "title": "Good Friday",
+                "date": "2017-04-14",
+                "notes": "",
+                "bunting": false
+            },
+            {
+                "title": "Easter Monday",
+                "date": "2017-04-17",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Early May bank holiday",
+                "date": "2017-05-01",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Spring bank holiday",
+                "date": "2017-05-29",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Summer bank holiday",
+                "date": "2017-08-28",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Christmas Day",
+                "date": "2017-12-25",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Boxing Day",
+                "date": "2017-12-26",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "New Year's Day",
+                "date": "2018-01-01",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Good Friday",
+                "date": "2018-03-30",
+                "notes": "",
+                "bunting": false
+            },
+            {
+                "title": "Easter Monday",
+                "date": "2018-04-02",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Early May bank holiday",
+                "date": "2018-05-07",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Spring bank holiday",
+                "date": "2018-05-28",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Summer bank holiday",
+                "date": "2018-08-27",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Christmas Day",
+                "date": "2018-12-25",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Boxing Day",
+                "date": "2018-12-26",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "New Year's Day",
+                "date": "2019-01-01",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Good Friday",
+                "date": "2019-04-19",
+                "notes": "",
+                "bunting": false
+            },
+            {
+                "title": "Easter Monday",
+                "date": "2019-04-22",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Early May bank holiday",
+                "date": "2019-05-06",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Spring bank holiday",
+                "date": "2019-05-27",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Summer bank holiday",
+                "date": "2019-08-26",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Christmas Day",
+                "date": "2019-12-25",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Boxing Day",
+                "date": "2019-12-26",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "New Year's Day",
+                "date": "2020-01-01",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Good Friday",
+                "date": "2020-04-10",
+                "notes": "",
+                "bunting": false
+            },
+            {
+                "title": "Easter Monday",
+                "date": "2020-04-13",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Easter Monday",
+                "date": "2020-04-13",
+                "notes": "",
+                "bunting": false
+            },
+            {
+                "title": "Early May bank holiday (VE day)",
+                "date": "2020-05-08",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Spring bank holiday",
+                "date": "2020-05-25",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Summer bank holiday",
+                "date": "2020-08-31",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Christmas Day",
+                "date": "2020-12-25",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Boxing Day",
+                "date": "2020-12-28",
+                "notes": "Substitute day",
+                "bunting": true
+            },
+            {
+                "title": "New Year's Day",
+                "date": "2021-01-01",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Good Friday",
+                "date": "2021-04-02",
+                "notes": "",
+                "bunting": false
+            },
+            {
+                "title": "Easter Monday",
+                "date": "2021-04-05",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Early May bank holiday",
+                "date": "2021-05-03",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Spring bank holiday",
+                "date": "2021-05-31",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Summer bank holiday",
+                "date": "2021-08-30",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Christmas Day",
+                "date": "2021-12-27",
+                "notes": "Substitute day",
+                "bunting": true
+            },
+            {
+                "title": "Boxing Day",
+                "date": "2021-12-28",
+                "notes": "Substitute day",
+                "bunting": true
+            },
+            {
+                "title": "New Year's Day",
+                "date": "2022-01-03",
+                "notes": "Substitute day",
+                "bunting": true
+            },
+            {
+                "title": "Good Friday",
+                "date": "2022-04-15",
+                "notes": "",
+                "bunting": false
+            },
+            {
+                "title": "Easter Monday",
+                "date": "2022-04-18",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Early May bank holiday",
+                "date": "2022-05-02",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Spring bank holiday",
+                "date": "2022-06-02",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Platinum Jubilee bank holiday",
+                "date": "2022-06-03",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Summer bank holiday",
+                "date": "2022-08-29",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Bank Holiday for the State Funeral of Queen Elizabeth II",
+                "date": "2022-09-19",
+                "notes": "",
+                "bunting": false
+            },
+            {
+                "title": "Boxing Day",
+                "date": "2022-12-26",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Christmas Day",
+                "date": "2022-12-27",
+                "notes": "Substitute day",
+                "bunting": true
+            },
+            {
+                "title": "New Year's Day",
+                "date": "2023-01-02",
+                "notes": "Substitute day",
+                "bunting": true
+            },
+            {
+                "title": "Good Friday",
+                "date": "2023-04-07",
+                "notes": "",
+                "bunting": false
+            },
+            {
+                "title": "Easter Monday",
+                "date": "2023-04-10",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Early May bank holiday",
+                "date": "2023-05-01",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Spring bank holiday",
+                "date": "2023-05-29",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Summer bank holiday",
+                "date": "2023-08-28",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Christmas Day",
+                "date": "2023-12-25",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Boxing Day",
+                "date": "2023-12-26",
+                "notes": "",
+                "bunting": true
+            }
+        ]
+    },
+    "scotland": {
+        "division": "scotland",
+        "events": [
+            {
+                "title": "2nd January",
+                "date": "2012-01-02",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "New Year's Day",
+                "date": "2012-01-03",
+                "notes": "Substitute day",
+                "bunting": true
+            },
+            {
+                "title": "Good Friday",
+                "date": "2012-04-06",
+                "notes": "",
+                "bunting": false
+            },
+            {
+                "title": "Early May bank holiday",
+                "date": "2012-05-07",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Spring bank holiday",
+                "date": "2012-06-04",
+                "notes": "Substitute day",
+                "bunting": true
+            },
+            {
+                "title": "Queen's Diamond Jubilee",
+                "date": "2012-06-05",
+                "notes": "Extra bank holiday",
+                "bunting": true
+            },
+            {
+                "title": "Summer bank holiday",
+                "date": "2012-08-06",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "St Andrew's Day",
+                "date": "2012-11-30",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Christmas Day",
+                "date": "2012-12-25",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Boxing Day",
+                "date": "2012-12-26",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "New Year's Day",
+                "date": "2013-01-01",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "2nd January",
+                "date": "2013-01-02",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Good Friday",
+                "date": "2013-03-29",
+                "notes": "",
+                "bunting": false
+            },
+            {
+                "title": "Early May bank holiday",
+                "date": "2013-05-06",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Spring bank holiday",
+                "date": "2013-05-27",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Summer bank holiday",
+                "date": "2013-08-05",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "St Andrew's Day",
+                "date": "2013-12-02",
+                "notes": "Substitute day",
+                "bunting": true
+            },
+            {
+                "title": "Christmas Day",
+                "date": "2013-12-25",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Boxing Day",
+                "date": "2013-12-26",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "New Year's Day",
+                "date": "2014-01-01",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "2nd January",
+                "date": "2014-01-02",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Good Friday",
+                "date": "2014-04-18",
+                "notes": "",
+                "bunting": false
+            },
+            {
+                "title": "Early May bank holiday",
+                "date": "2014-05-05",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Spring bank holiday",
+                "date": "2014-05-26",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Summer bank holiday",
+                "date": "2014-08-04",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "St Andrew's Day",
+                "date": "2014-12-01",
+                "notes": "Substitute day",
+                "bunting": true
+            },
+            {
+                "title": "Christmas Day",
+                "date": "2014-12-25",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Boxing Day",
+                "date": "2014-12-26",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "New Year's Day",
+                "date": "2015-01-01",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "2nd January",
+                "date": "2015-01-02",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Good Friday",
+                "date": "2015-04-03",
+                "notes": "",
+                "bunting": false
+            },
+            {
+                "title": "Early May bank holiday",
+                "date": "2015-05-04",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Spring bank holiday",
+                "date": "2015-05-25",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Summer bank holiday",
+                "date": "2015-08-03",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "St Andrew's Day",
+                "date": "2015-11-30",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Christmas Day",
+                "date": "2015-12-25",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Boxing Day",
+                "date": "2015-12-28",
+                "notes": "Substitute day",
+                "bunting": true
+            },
+            {
+                "title": "New Year's Day",
+                "date": "2016-01-01",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "2nd January",
+                "date": "2016-01-04",
+                "notes": "Substitute day",
+                "bunting": true
+            },
+            {
+                "title": "Good Friday",
+                "date": "2016-03-25",
+                "notes": "",
+                "bunting": false
+            },
+            {
+                "title": "Early May bank holiday",
+                "date": "2016-05-02",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Spring bank holiday",
+                "date": "2016-05-30",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Summer bank holiday",
+                "date": "2016-08-01",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "St Andrew's Day",
+                "date": "2016-11-30",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Boxing Day",
+                "date": "2016-12-26",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Christmas Day",
+                "date": "2016-12-27",
+                "notes": "Substitute day",
+                "bunting": true
+            },
+            {
+                "title": "2nd January",
+                "date": "2017-01-02",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "New Year's Day",
+                "date": "2017-01-03",
+                "notes": "Substitute day",
+                "bunting": true
+            },
+            {
+                "title": "Good Friday",
+                "date": "2017-04-14",
+                "notes": "",
+                "bunting": false
+            },
+            {
+                "title": "Early May bank holiday",
+                "date": "2017-05-01",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Spring bank holiday",
+                "date": "2017-05-29",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Summer bank holiday",
+                "date": "2017-08-07",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "St Andrew's Day",
+                "date": "2017-11-30",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Christmas Day",
+                "date": "2017-12-25",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Boxing Day",
+                "date": "2017-12-26",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "New Year's Day",
+                "date": "2018-01-01",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "2nd January",
+                "date": "2018-01-02",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Good Friday",
+                "date": "2018-03-30",
+                "notes": "",
+                "bunting": false
+            },
+            {
+                "title": "Early May bank holiday",
+                "date": "2018-05-07",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Spring bank holiday",
+                "date": "2018-05-28",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Summer bank holiday",
+                "date": "2018-08-06",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "St Andrew's Day",
+                "date": "2018-11-30",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Christmas Day",
+                "date": "2018-12-25",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Boxing Day",
+                "date": "2018-12-26",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "New Year's Day",
+                "date": "2019-01-01",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "2nd January",
+                "date": "2019-01-02",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Good Friday",
+                "date": "2019-04-19",
+                "notes": "",
+                "bunting": false
+            },
+            {
+                "title": "Early May bank holiday",
+                "date": "2019-05-06",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Spring bank holiday",
+                "date": "2019-05-27",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Summer bank holiday",
+                "date": "2019-08-05",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "St Andrew's Day",
+                "date": "2019-12-02",
+                "notes": "Substitute day",
+                "bunting": true
+            },
+            {
+                "title": "Christmas Day",
+                "date": "2019-12-25",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Boxing Day",
+                "date": "2019-12-26",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "New Year's Day",
+                "date": "2020-01-01",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "2nd January",
+                "date": "2020-01-02",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Good Friday",
+                "date": "2020-04-10",
+                "notes": "",
+                "bunting": false
+            },
+            {
+                "title": "Early May bank holiday (VE day)",
+                "date": "2020-05-08",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Spring bank holiday",
+                "date": "2020-05-25",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Summer bank holiday",
+                "date": "2020-08-03",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "St Andrew's Day",
+                "date": "2020-11-30",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Christmas Day",
+                "date": "2020-12-25",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Boxing Day",
+                "date": "2020-12-28",
+                "notes": "Substitute day",
+                "bunting": true
+            },
+            {
+                "title": "New Year's Day",
+                "date": "2021-01-01",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "2nd January",
+                "date": "2021-01-04",
+                "notes": "Substitute day",
+                "bunting": true
+            },
+            {
+                "title": "Good Friday",
+                "date": "2021-04-02",
+                "notes": "",
+                "bunting": false
+            },
+            {
+                "title": "Early May bank holiday",
+                "date": "2021-05-03",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Spring bank holiday",
+                "date": "2021-05-31",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Summer bank holiday",
+                "date": "2021-08-02",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "St Andrew's Day",
+                "date": "2021-11-30",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Christmas Day",
+                "date": "2021-12-27",
+                "notes": "Substitute day",
+                "bunting": true
+            },
+            {
+                "title": "Boxing Day",
+                "date": "2021-12-28",
+                "notes": "Substitute day",
+                "bunting": true
+            },
+            {
+                "title": "New Year's Day",
+                "date": "2022-01-03",
+                "notes": "Substitute day",
+                "bunting": true
+            },
+            {
+                "title": "2nd January",
+                "date": "2022-01-04",
+                "notes": "Substitute day",
+                "bunting": true
+            },
+            {
+                "title": "Good Friday",
+                "date": "2022-04-15",
+                "notes": "",
+                "bunting": false
+            },
+            {
+                "title": "Early May bank holiday",
+                "date": "2022-05-02",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Spring bank holiday",
+                "date": "2022-06-02",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Platinum Jubilee bank holiday",
+                "date": "2022-06-03",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Summer bank holiday",
+                "date": "2022-08-01",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Bank Holiday for the State Funeral of Queen Elizabeth II",
+                "date": "2022-09-19",
+                "notes": "",
+                "bunting": false
+            },
+            {
+                "title": "St Andrew's Day",
+                "date": "2022-11-30",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Boxing Day",
+                "date": "2022-12-26",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Christmas Day",
+                "date": "2022-12-27",
+                "notes": "Substitute day",
+                "bunting": true
+            },
+            {
+                "title": "New Year's Day",
+                "date": "2023-01-02",
+                "notes": "Substitute day",
+                "bunting": true
+            },
+            {
+                "title": "2nd January",
+                "date": "2023-01-03",
+                "notes": "Substitute day",
+                "bunting": true
+            },
+            {
+                "title": "Good Friday",
+                "date": "2023-04-07",
+                "notes": "",
+                "bunting": false
+            },
+            {
+                "title": "Early May bank holiday",
+                "date": "2023-05-01",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Spring bank holiday",
+                "date": "2023-05-29",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Summer bank holiday",
+                "date": "2023-08-07",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "St Andrew's Day",
+                "date": "2023-11-30",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Christmas Day",
+                "date": "2023-12-25",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Boxing Day",
+                "date": "2023-12-26",
+                "notes": "",
+                "bunting": true
+            }
+        ]
+    },
+    "northern-ireland": {
+        "division": "northern-ireland",
+        "events": [
+            {
+                "title": "New Year's Day",
+                "date": "2012-01-02",
+                "notes": "Substitute day",
+                "bunting": true
+            },
+            {
+                "title": "St Patrick's Day",
+                "date": "2012-03-19",
+                "notes": "Substitute day",
+                "bunting": true
+            },
+            {
+                "title": "Good Friday",
+                "date": "2012-04-06",
+                "notes": "",
+                "bunting": false
+            },
+            {
+                "title": "Easter Monday",
+                "date": "2012-04-09",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Early May bank holiday",
+                "date": "2012-05-07",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Spring bank holiday",
+                "date": "2012-06-04",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Queen's Diamond Jubilee",
+                "date": "2012-06-05",
+                "notes": "Extra bank holiday",
+                "bunting": true
+            },
+            {
+                "title": "Battle of the Boyne (Orangemen's Day)",
+                "date": "2012-07-12",
+                "notes": "",
+                "bunting": false
+            },
+            {
+                "title": "Summer bank holiday",
+                "date": "2012-08-27",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Christmas Day",
+                "date": "2012-12-25",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Boxing Day",
+                "date": "2012-12-26",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "New Year's Day",
+                "date": "2013-01-01",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "St Patrick's Day",
+                "date": "2013-03-18",
+                "notes": "Substitute day",
+                "bunting": true
+            },
+            {
+                "title": "Good Friday",
+                "date": "2013-03-29",
+                "notes": "",
+                "bunting": false
+            },
+            {
+                "title": "Easter Monday",
+                "date": "2013-04-01",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Early May bank holiday",
+                "date": "2013-05-06",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Spring bank holiday",
+                "date": "2013-05-27",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Battle of the Boyne (Orangemen's Day)",
+                "date": "2013-07-12",
+                "notes": "",
+                "bunting": false
+            },
+            {
+                "title": "Summer bank holiday",
+                "date": "2013-08-26",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Christmas Day",
+                "date": "2013-12-25",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Boxing Day",
+                "date": "2013-12-26",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "New Year's Day",
+                "date": "2014-01-01",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "St Patrick's Day",
+                "date": "2014-03-17",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Good Friday",
+                "date": "2014-04-18",
+                "notes": "",
+                "bunting": false
+            },
+            {
+                "title": "Easter Monday",
+                "date": "2014-04-21",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Early May bank holiday",
+                "date": "2014-05-05",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Spring bank holiday",
+                "date": "2014-05-26",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Battle of the Boyne (Orangemen's Day)",
+                "date": "2014-07-14",
+                "notes": "Substitute day",
+                "bunting": false
+            },
+            {
+                "title": "Summer bank holiday",
+                "date": "2014-08-25",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Christmas Day",
+                "date": "2014-12-25",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Boxing Day",
+                "date": "2014-12-26",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "New Year's Day",
+                "date": "2015-01-01",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "St Patrick's Day",
+                "date": "2015-03-17",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Good Friday",
+                "date": "2015-04-03",
+                "notes": "",
+                "bunting": false
+            },
+            {
+                "title": "Easter Monday",
+                "date": "2015-04-06",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Early May bank holiday",
+                "date": "2015-05-04",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Spring bank holiday",
+                "date": "2015-05-25",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Battle of the Boyne (Orangemen's Day)",
+                "date": "2015-07-13",
+                "notes": "Substitute day",
+                "bunting": false
+            },
+            {
+                "title": "Summer bank holiday",
+                "date": "2015-08-31",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Christmas Day",
+                "date": "2015-12-25",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Boxing Day",
+                "date": "2015-12-28",
+                "notes": "Substitute day",
+                "bunting": true
+            },
+            {
+                "title": "New Year's Day",
+                "date": "2016-01-01",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "St Patrick's Day",
+                "date": "2016-03-17",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Good Friday",
+                "date": "2016-03-25",
+                "notes": "",
+                "bunting": false
+            },
+            {
+                "title": "Easter Monday",
+                "date": "2016-03-28",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Early May bank holiday",
+                "date": "2016-05-02",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Spring bank holiday",
+                "date": "2016-05-30",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Battle of the Boyne (Orangemen's Day)",
+                "date": "2016-07-12",
+                "notes": "",
+                "bunting": false
+            },
+            {
+                "title": "Summer bank holiday",
+                "date": "2016-08-29",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Boxing Day",
+                "date": "2016-12-26",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Christmas Day",
+                "date": "2016-12-27",
+                "notes": "Substitute day",
+                "bunting": true
+            },
+            {
+                "title": "New Year's Day",
+                "date": "2017-01-02",
+                "notes": "Substitute day",
+                "bunting": true
+            },
+            {
+                "title": "St Patrick's Day",
+                "date": "2017-03-17",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Good Friday",
+                "date": "2017-04-14",
+                "notes": "",
+                "bunting": false
+            },
+            {
+                "title": "Easter Monday",
+                "date": "2017-04-17",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Early May bank holiday",
+                "date": "2017-05-01",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Spring bank holiday",
+                "date": "2017-05-29",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Battle of the Boyne (Orangemen's Day)",
+                "date": "2017-07-12",
+                "notes": "",
+                "bunting": false
+            },
+            {
+                "title": "Summer bank holiday",
+                "date": "2017-08-28",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Christmas Day",
+                "date": "2017-12-25",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Boxing Day",
+                "date": "2017-12-26",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "New Year's Day",
+                "date": "2018-01-01",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "St Patrick's Day",
+                "date": "2018-03-19",
+                "notes": "Substitute day",
+                "bunting": true
+            },
+            {
+                "title": "Good Friday",
+                "date": "2018-03-30",
+                "notes": "",
+                "bunting": false
+            },
+            {
+                "title": "Easter Monday",
+                "date": "2018-04-02",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Early May bank holiday",
+                "date": "2018-05-07",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Spring bank holiday",
+                "date": "2018-05-28",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Battle of the Boyne (Orangemen's Day)",
+                "date": "2018-07-12",
+                "notes": "",
+                "bunting": false
+            },
+            {
+                "title": "Summer bank holiday",
+                "date": "2018-08-27",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Christmas Day",
+                "date": "2018-12-25",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Boxing Day",
+                "date": "2018-12-26",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "New Year's Day",
+                "date": "2019-01-01",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "St Patrick's Day",
+                "date": "2019-03-18",
+                "notes": "Substitute day",
+                "bunting": true
+            },
+            {
+                "title": "Good Friday",
+                "date": "2019-04-19",
+                "notes": "",
+                "bunting": false
+            },
+            {
+                "title": "Easter Monday",
+                "date": "2019-04-22",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Early May bank holiday",
+                "date": "2019-05-06",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Spring bank holiday",
+                "date": "2019-05-27",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Battle of the Boyne (Orangemen's Day)",
+                "date": "2019-07-12",
+                "notes": "",
+                "bunting": false
+            },
+            {
+                "title": "Summer bank holiday",
+                "date": "2019-08-26",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Christmas Day",
+                "date": "2019-12-25",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Boxing Day",
+                "date": "2019-12-26",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "New Year's Day",
+                "date": "2020-01-01",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "St Patrick's Day",
+                "date": "2020-03-17",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Good Friday",
+                "date": "2020-04-10",
+                "notes": "",
+                "bunting": false
+            },
+            {
+                "title": "Easter Monday",
+                "date": "2020-04-13",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Easter Monday",
+                "date": "2020-04-13",
+                "notes": "",
+                "bunting": false
+            },
+            {
+                "title": "Early May bank holiday (VE day)",
+                "date": "2020-05-08",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Spring bank holiday",
+                "date": "2020-05-25",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Battle of the Boyne (Orangemen's Day)",
+                "date": "2020-07-13",
+                "notes": "Substitute day",
+                "bunting": false
+            },
+            {
+                "title": "Summer bank holiday",
+                "date": "2020-08-31",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Christmas Day",
+                "date": "2020-12-25",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Boxing Day",
+                "date": "2020-12-28",
+                "notes": "Substitute day",
+                "bunting": true
+            },
+            {
+                "title": "New Year's Day",
+                "date": "2021-01-01",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "St Patrick's Day",
+                "date": "2021-03-17",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Good Friday",
+                "date": "2021-04-02",
+                "notes": "",
+                "bunting": false
+            },
+            {
+                "title": "Easter Monday",
+                "date": "2021-04-05",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Early May bank holiday",
+                "date": "2021-05-03",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Spring bank holiday",
+                "date": "2021-05-31",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Battle of the Boyne (Orangemen's Day)",
+                "date": "2021-07-12",
+                "notes": "",
+                "bunting": false
+            },
+            {
+                "title": "Summer bank holiday",
+                "date": "2021-08-30",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Christmas Day",
+                "date": "2021-12-27",
+                "notes": "Substitute day",
+                "bunting": true
+            },
+            {
+                "title": "Boxing Day",
+                "date": "2021-12-28",
+                "notes": "Substitute day",
+                "bunting": true
+            },
+            {
+                "title": "New Year's Day",
+                "date": "2022-01-03",
+                "notes": "Substitute day",
+                "bunting": true
+            },
+            {
+                "title": "St Patrick's Day",
+                "date": "2022-03-17",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Good Friday",
+                "date": "2022-04-15",
+                "notes": "",
+                "bunting": false
+            },
+            {
+                "title": "Easter Monday",
+                "date": "2022-04-18",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Early May bank holiday",
+                "date": "2022-05-02",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Spring bank holiday",
+                "date": "2022-06-02",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Platinum Jubilee bank holiday",
+                "date": "2022-06-03",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Battle of the Boyne (Orangemen's Day)",
+                "date": "2022-07-12",
+                "notes": "",
+                "bunting": false
+            },
+            {
+                "title": "Summer bank holiday",
+                "date": "2022-08-29",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Bank Holiday for the State Funeral of Queen Elizabeth II",
+                "date": "2022-09-19",
+                "notes": "",
+                "bunting": false
+            },
+            {
+                "title": "Boxing Day",
+                "date": "2022-12-26",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Christmas Day",
+                "date": "2022-12-27",
+                "notes": "Substitute day",
+                "bunting": true
+            },
+            {
+                "title": "New Year's Day",
+                "date": "2023-01-02",
+                "notes": "Substitute day",
+                "bunting": true
+            },
+            {
+                "title": "St Patrick's Day",
+                "date": "2023-03-17",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Good Friday",
+                "date": "2023-04-07",
+                "notes": "",
+                "bunting": false
+            },
+            {
+                "title": "Easter Monday",
+                "date": "2023-04-10",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Early May bank holiday",
+                "date": "2023-05-01",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Spring bank holiday",
+                "date": "2023-05-29",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Battle of the Boyne (Orangemen's Day)",
+                "date": "2023-07-12",
+                "notes": "",
+                "bunting": false
+            },
+            {
+                "title": "Summer bank holiday",
+                "date": "2023-08-28",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Christmas Day",
+                "date": "2023-12-25",
+                "notes": "",
+                "bunting": true
+            },
+            {
+                "title": "Boxing Day",
+                "date": "2023-12-26",
+                "notes": "",
+                "bunting": true
+            }
+        ]
+    }
+}

--- a/uk_election_timetables/bank-holidays.json
+++ b/uk_election_timetables/bank-holidays.json
@@ -249,7 +249,7 @@
                 "bunting": true
             },
             {
-                "title": "New Year's Day",
+                "title": "New Year’s Day",
                 "date": "2017-01-02",
                 "notes": "Substitute day",
                 "bunting": true
@@ -297,7 +297,7 @@
                 "bunting": true
             },
             {
-                "title": "New Year's Day",
+                "title": "New Year’s Day",
                 "date": "2018-01-01",
                 "notes": "",
                 "bunting": true
@@ -345,7 +345,7 @@
                 "bunting": true
             },
             {
-                "title": "New Year's Day",
+                "title": "New Year’s Day",
                 "date": "2019-01-01",
                 "notes": "",
                 "bunting": true
@@ -393,7 +393,7 @@
                 "bunting": true
             },
             {
-                "title": "New Year's Day",
+                "title": "New Year’s Day",
                 "date": "2020-01-01",
                 "notes": "",
                 "bunting": true
@@ -403,12 +403,6 @@
                 "date": "2020-04-10",
                 "notes": "",
                 "bunting": false
-            },
-            {
-                "title": "Easter Monday",
-                "date": "2020-04-13",
-                "notes": "",
-                "bunting": true
             },
             {
                 "title": "Easter Monday",
@@ -447,7 +441,7 @@
                 "bunting": true
             },
             {
-                "title": "New Year's Day",
+                "title": "New Year’s Day",
                 "date": "2021-01-01",
                 "notes": "",
                 "bunting": true
@@ -495,7 +489,7 @@
                 "bunting": true
             },
             {
-                "title": "New Year's Day",
+                "title": "New Year’s Day",
                 "date": "2022-01-03",
                 "notes": "Substitute day",
                 "bunting": true
@@ -555,7 +549,7 @@
                 "bunting": true
             },
             {
-                "title": "New Year's Day",
+                "title": "New Year’s Day",
                 "date": "2023-01-02",
                 "notes": "Substitute day",
                 "bunting": true
@@ -890,7 +884,7 @@
                 "bunting": true
             },
             {
-                "title": "New Year's Day",
+                "title": "New Year’s Day",
                 "date": "2017-01-03",
                 "notes": "Substitute day",
                 "bunting": true
@@ -920,7 +914,7 @@
                 "bunting": true
             },
             {
-                "title": "St Andrew's Day",
+                "title": "St Andrew’s Day",
                 "date": "2017-11-30",
                 "notes": "",
                 "bunting": true
@@ -938,7 +932,7 @@
                 "bunting": true
             },
             {
-                "title": "New Year's Day",
+                "title": "New Year’s Day",
                 "date": "2018-01-01",
                 "notes": "",
                 "bunting": true
@@ -974,7 +968,7 @@
                 "bunting": true
             },
             {
-                "title": "St Andrew's Day",
+                "title": "St Andrew’s Day",
                 "date": "2018-11-30",
                 "notes": "",
                 "bunting": true
@@ -992,7 +986,7 @@
                 "bunting": true
             },
             {
-                "title": "New Year's Day",
+                "title": "New Year’s Day",
                 "date": "2019-01-01",
                 "notes": "",
                 "bunting": true
@@ -1028,7 +1022,7 @@
                 "bunting": true
             },
             {
-                "title": "St Andrew's Day",
+                "title": "St Andrew’s Day",
                 "date": "2019-12-02",
                 "notes": "Substitute day",
                 "bunting": true
@@ -1046,7 +1040,7 @@
                 "bunting": true
             },
             {
-                "title": "New Year's Day",
+                "title": "New Year’s Day",
                 "date": "2020-01-01",
                 "notes": "",
                 "bunting": true
@@ -1082,7 +1076,7 @@
                 "bunting": true
             },
             {
-                "title": "St Andrew's Day",
+                "title": "St Andrew’s Day",
                 "date": "2020-11-30",
                 "notes": "",
                 "bunting": true
@@ -1100,7 +1094,7 @@
                 "bunting": true
             },
             {
-                "title": "New Year's Day",
+                "title": "New Year’s Day",
                 "date": "2021-01-01",
                 "notes": "",
                 "bunting": true
@@ -1136,7 +1130,7 @@
                 "bunting": true
             },
             {
-                "title": "St Andrew's Day",
+                "title": "St Andrew’s Day",
                 "date": "2021-11-30",
                 "notes": "",
                 "bunting": true
@@ -1154,7 +1148,7 @@
                 "bunting": true
             },
             {
-                "title": "New Year's Day",
+                "title": "New Year’s Day",
                 "date": "2022-01-03",
                 "notes": "Substitute day",
                 "bunting": true
@@ -1202,7 +1196,7 @@
                 "bunting": false
             },
             {
-                "title": "St Andrew's Day",
+                "title": "St Andrew’s Day",
                 "date": "2022-11-30",
                 "notes": "",
                 "bunting": true
@@ -1220,7 +1214,7 @@
                 "bunting": true
             },
             {
-                "title": "New Year's Day",
+                "title": "New Year’s Day",
                 "date": "2023-01-02",
                 "notes": "Substitute day",
                 "bunting": true
@@ -1256,7 +1250,7 @@
                 "bunting": true
             },
             {
-                "title": "St Andrew's Day",
+                "title": "St Andrew’s Day",
                 "date": "2023-11-30",
                 "notes": "",
                 "bunting": true
@@ -1585,13 +1579,13 @@
                 "bunting": true
             },
             {
-                "title": "New Year's Day",
+                "title": "New Year’s Day",
                 "date": "2017-01-02",
                 "notes": "Substitute day",
                 "bunting": true
             },
             {
-                "title": "St Patrick's Day",
+                "title": "St Patrick’s Day",
                 "date": "2017-03-17",
                 "notes": "",
                 "bunting": true
@@ -1621,7 +1615,7 @@
                 "bunting": true
             },
             {
-                "title": "Battle of the Boyne (Orangemen's Day)",
+                "title": "Battle of the Boyne (Orangemen’s Day)",
                 "date": "2017-07-12",
                 "notes": "",
                 "bunting": false
@@ -1645,13 +1639,13 @@
                 "bunting": true
             },
             {
-                "title": "New Year's Day",
+                "title": "New Year’s Day",
                 "date": "2018-01-01",
                 "notes": "",
                 "bunting": true
             },
             {
-                "title": "St Patrick's Day",
+                "title": "St Patrick’s Day",
                 "date": "2018-03-19",
                 "notes": "Substitute day",
                 "bunting": true
@@ -1681,7 +1675,7 @@
                 "bunting": true
             },
             {
-                "title": "Battle of the Boyne (Orangemen's Day)",
+                "title": "Battle of the Boyne (Orangemen’s Day)",
                 "date": "2018-07-12",
                 "notes": "",
                 "bunting": false
@@ -1705,13 +1699,13 @@
                 "bunting": true
             },
             {
-                "title": "New Year's Day",
+                "title": "New Year’s Day",
                 "date": "2019-01-01",
                 "notes": "",
                 "bunting": true
             },
             {
-                "title": "St Patrick's Day",
+                "title": "St Patrick’s Day",
                 "date": "2019-03-18",
                 "notes": "Substitute day",
                 "bunting": true
@@ -1741,7 +1735,7 @@
                 "bunting": true
             },
             {
-                "title": "Battle of the Boyne (Orangemen's Day)",
+                "title": "Battle of the Boyne (Orangemen’s Day)",
                 "date": "2019-07-12",
                 "notes": "",
                 "bunting": false
@@ -1765,13 +1759,13 @@
                 "bunting": true
             },
             {
-                "title": "New Year's Day",
+                "title": "New Year’s Day",
                 "date": "2020-01-01",
                 "notes": "",
                 "bunting": true
             },
             {
-                "title": "St Patrick's Day",
+                "title": "St Patrick’s Day",
                 "date": "2020-03-17",
                 "notes": "",
                 "bunting": true
@@ -1781,12 +1775,6 @@
                 "date": "2020-04-10",
                 "notes": "",
                 "bunting": false
-            },
-            {
-                "title": "Easter Monday",
-                "date": "2020-04-13",
-                "notes": "",
-                "bunting": true
             },
             {
                 "title": "Easter Monday",
@@ -1807,7 +1795,7 @@
                 "bunting": true
             },
             {
-                "title": "Battle of the Boyne (Orangemen's Day)",
+                "title": "Battle of the Boyne (Orangemen’s Day)",
                 "date": "2020-07-13",
                 "notes": "Substitute day",
                 "bunting": false
@@ -1831,13 +1819,13 @@
                 "bunting": true
             },
             {
-                "title": "New Year's Day",
+                "title": "New Year’s Day",
                 "date": "2021-01-01",
                 "notes": "",
                 "bunting": true
             },
             {
-                "title": "St Patrick's Day",
+                "title": "St Patrick’s Day",
                 "date": "2021-03-17",
                 "notes": "",
                 "bunting": true
@@ -1867,7 +1855,7 @@
                 "bunting": true
             },
             {
-                "title": "Battle of the Boyne (Orangemen's Day)",
+                "title": "Battle of the Boyne (Orangemen’s Day)",
                 "date": "2021-07-12",
                 "notes": "",
                 "bunting": false
@@ -1891,13 +1879,13 @@
                 "bunting": true
             },
             {
-                "title": "New Year's Day",
+                "title": "New Year’s Day",
                 "date": "2022-01-03",
                 "notes": "Substitute day",
                 "bunting": true
             },
             {
-                "title": "St Patrick's Day",
+                "title": "St Patrick’s Day",
                 "date": "2022-03-17",
                 "notes": "",
                 "bunting": true
@@ -1933,7 +1921,7 @@
                 "bunting": true
             },
             {
-                "title": "Battle of the Boyne (Orangemen's Day)",
+                "title": "Battle of the Boyne (Orangemen’s Day)",
                 "date": "2022-07-12",
                 "notes": "",
                 "bunting": false
@@ -1963,13 +1951,13 @@
                 "bunting": true
             },
             {
-                "title": "New Year's Day",
+                "title": "New Year’s Day",
                 "date": "2023-01-02",
                 "notes": "Substitute day",
                 "bunting": true
             },
             {
-                "title": "St Patrick's Day",
+                "title": "St Patrick’s Day",
                 "date": "2023-03-17",
                 "notes": "",
                 "bunting": true
@@ -1999,7 +1987,7 @@
                 "bunting": true
             },
             {
-                "title": "Battle of the Boyne (Orangemen's Day)",
+                "title": "Battle of the Boyne (Orangemen’s Day)",
                 "date": "2023-07-12",
                 "notes": "",
                 "bunting": false

--- a/uk_election_timetables/bank_holidays.py
+++ b/uk_election_timetables/bank_holidays.py
@@ -41,11 +41,15 @@ def combine_bank_holiday_lists(existing_dataset: Dict, new_dataset: Dict) -> Dic
 
 
 def update_bank_holidays() -> None:
+    """
+    Fetch bank holiday data from our master file and .gov source and perform update
+    :return: None
+    """
     bank_holiday_json_path: str = os.path.join( os.path.dirname(__file__), "bank-holidays.json")
     with open(bank_holiday_json_path, "r") as file:
         current_data: Dict = json.load(file)
 
     gov_data: Dict = requests.get("https://www.gov.uk/bank-holidays.json").json()
-    updated_dataset = combine_bank_holiday_lists(current_data, gov_data)
+    updated_dataset: Dict = combine_bank_holiday_lists(current_data, gov_data)
     with open(bank_holiday_json_path, "w") as file:
-        file.write(json.dumps(updated_dataset))
+        file.write(json.dumps(updated_dataset, indent=4))

--- a/uk_election_timetables/bank_holidays.py
+++ b/uk_election_timetables/bank_holidays.py
@@ -1,3 +1,7 @@
+import os
+import json
+import requests
+
 from typing import Dict, List
 
 
@@ -35,3 +39,13 @@ def combine_bank_holiday_lists(existing_dataset: Dict, new_dataset: Dict) -> Dic
 
     return combined_dataset
 
+
+def update_bank_holidays() -> None:
+    bank_holiday_json_path: str = os.path.join( os.path.dirname(__file__), "bank-holidays.json")
+    with open(bank_holiday_json_path, "r") as file:
+        current_data: Dict = json.load(file)
+
+    gov_data: Dict = requests.get("https://www.gov.uk/bank-holidays.json").json()
+    updated_dataset = combine_bank_holiday_lists(current_data, gov_data)
+    with open(bank_holiday_json_path, "w") as file:
+        file.write(json.dumps(updated_dataset))

--- a/uk_election_timetables/bank_holidays.py
+++ b/uk_election_timetables/bank_holidays.py
@@ -1,0 +1,20 @@
+from typing import Dict, List
+
+
+def get_additions_count(existing_dataset: Dict, new_dataset: Dict) -> int:
+    """
+    Get the number of additions in new_dataset when compared to existing_dataset
+    :param existing_dataset: Seeded dict of historical dates (usually bank-holidays.json)
+    :param new_dataset: Dict of new bank holiday dates (usually https://www.gov.uk/bank-holidays.json)
+    :return: int
+    """
+    total_count: int = 0
+    for key in new_dataset.keys():
+        try:
+            current_events: List = existing_dataset[key]["events"]
+            new_events: List = new_dataset[key]["events"]
+        except KeyError as ex:
+            print(f"Unable to find key: {ex}")
+            return 0
+        total_count += sum([1 for x in new_events if x not in current_events])
+    return total_count

--- a/uk_election_timetables/bank_holidays.py
+++ b/uk_election_timetables/bank_holidays.py
@@ -10,11 +10,28 @@ def get_additions_count(existing_dataset: Dict, new_dataset: Dict) -> int:
     """
     total_count: int = 0
     for key in new_dataset.keys():
-        try:
-            current_events: List = existing_dataset[key]["events"]
-            new_events: List = new_dataset[key]["events"]
-        except KeyError as ex:
-            print(f"Unable to find key: {ex}")
-            return 0
+        current_events: List = existing_dataset.get(key, {}).get("events", [])
+        new_events: List = new_dataset.get(key, {}).get("events", [])
         total_count += sum([1 for x in new_events if x not in current_events])
+
     return total_count
+
+
+def combine_bank_holiday_lists(existing_dataset: Dict, new_dataset: Dict) -> Dict:
+    """
+    Create dict containing all values from existing dataset and all new values from new dataset
+    :param existing_dataset: Seeded dict of historical dates (usually bank-holidays.json)
+    :param new_dataset: Dict of new bank holiday dates (usually https://www.gov.uk/bank-holidays.json)
+    :return: Dict
+    """
+    combined_dataset = existing_dataset
+    for key in new_dataset.keys():
+        current_events: List = existing_dataset.get(key, {}).get("events", [])
+        new_events: List = new_dataset.get(key, {}).get("events", [])
+        all_events = current_events + [x for x in new_events if x not in current_events]
+
+        all_events = sorted(all_events, key=lambda d: d['date'])
+        combined_dataset[key]["events"] = all_events
+
+    return combined_dataset
+

--- a/uk_election_timetables/bank_holidays.py
+++ b/uk_election_timetables/bank_holidays.py
@@ -38,13 +38,19 @@ def combine_bank_holiday_lists(existing_dataset: Dict, new_dataset: Dict) -> Dic
         new_events: List = new_dataset.get(key, {}).get("events", [])
         new_events = sorted(new_events, key=lambda d: d["date"])
 
-        combined_events: List = current_events + [x for x in new_events if x not in current_events]
+        combined_events: List = current_events + [
+            x for x in new_events if x not in current_events
+        ]
         combined_events = sorted(combined_events, key=lambda d: d["date"])
 
         # Remove duplicated records (any events within date range of .gov list which are not present in .gov list)
-        earliest_new_event: datetime.date = datetime.strptime(new_events[0]["date"], '%Y-%m-%d').date()
+        earliest_new_event: datetime.date = datetime.strptime(
+            new_events[0]["date"], "%Y-%m-%d"
+        ).date()
         for event in combined_events:
-            event_date: datetime.date = datetime.strptime(event["date"], '%Y-%m-%d').date()
+            event_date: datetime.date = datetime.strptime(
+                event["date"], "%Y-%m-%d"
+            ).date()
             if (event_date >= earliest_new_event) and (event not in new_events):
                 combined_events.remove(event)
 
@@ -58,7 +64,9 @@ def diff_bank_holidays() -> int:
     Fetch bank holiday data from our local file and .gov source and return number of additions in diff
     :return: int
     """
-    bank_holiday_json_path: str = os.path.join(os.path.dirname(__file__), LOCAL_BANK_HOLIDAY_FILE)
+    bank_holiday_json_path: str = os.path.join(
+        os.path.dirname(__file__), LOCAL_BANK_HOLIDAY_FILE
+    )
     with open(bank_holiday_json_path, "r") as file:
         current_data: Dict = json.load(file)
 
@@ -71,7 +79,9 @@ def update_bank_holidays() -> None:
     Fetch bank holiday data from our local file and .gov source and perform update
     :return: None
     """
-    bank_holiday_json_path: str = os.path.join(os.path.dirname(__file__), LOCAL_BANK_HOLIDAY_FILE)
+    bank_holiday_json_path: str = os.path.join(
+        os.path.dirname(__file__), LOCAL_BANK_HOLIDAY_FILE
+    )
     with open(bank_holiday_json_path, "r") as file:
         current_data: Dict = json.load(file)
 

--- a/uk_election_timetables/bank_holidays.py
+++ b/uk_election_timetables/bank_holidays.py
@@ -1,6 +1,7 @@
 import os
 import json
 import requests
+from datetime import datetime
 
 from typing import Dict, List
 
@@ -35,10 +36,19 @@ def combine_bank_holiday_lists(existing_dataset: Dict, new_dataset: Dict) -> Dic
     for key in new_dataset.keys():
         current_events: List = existing_dataset.get(key, {}).get("events", [])
         new_events: List = new_dataset.get(key, {}).get("events", [])
-        all_events = current_events + [x for x in new_events if x not in current_events]
+        new_events = sorted(new_events, key=lambda d: d["date"])
 
-        all_events = sorted(all_events, key=lambda d: d['date'])
-        combined_dataset[key]["events"] = all_events
+        combined_events: List = current_events + [x for x in new_events if x not in current_events]
+        combined_events = sorted(combined_events, key=lambda d: d["date"])
+
+        # Remove duplicated records (any events within date range of .gov list which are not present in .gov list)
+        earliest_new_event: datetime.date = datetime.strptime(new_events[0]["date"], '%Y-%m-%d').date()
+        for event in combined_events:
+            event_date: datetime.date = datetime.strptime(event["date"], '%Y-%m-%d').date()
+            if (event_date >= earliest_new_event) and (event not in new_events):
+                combined_events.remove(event)
+
+        combined_dataset[key]["events"] = combined_events
 
     return combined_dataset
 
@@ -61,11 +71,11 @@ def update_bank_holidays() -> None:
     Fetch bank holiday data from our local file and .gov source and perform update
     :return: None
     """
-    bank_holiday_json_path: str = os.path.join( os.path.dirname(__file__), LOCAL_BANK_HOLIDAY_FILE)
+    bank_holiday_json_path: str = os.path.join(os.path.dirname(__file__), LOCAL_BANK_HOLIDAY_FILE)
     with open(bank_holiday_json_path, "r") as file:
         current_data: Dict = json.load(file)
 
     gov_data: Dict = requests.get(GOV_BANK_HOLIDAY_URL).json()
     updated_dataset: Dict = combine_bank_holiday_lists(current_data, gov_data)
     with open(bank_holiday_json_path, "w") as file:
-        file.write(json.dumps(updated_dataset, indent=4))
+        json.dump(updated_dataset, file, indent=4, ensure_ascii=False)


### PR DESCRIPTION
Aims to address #19 

As well as maintaining historical dates, this includes: 
- Modifying the cron job to run a python function instead of bash diff
- Pretty-printing the json file so we can more easily see changes when they come through 
- New function to perform the update to the json file