### PR TITLE
Add VAC application deadline to election/timetable

### DIFF
--- a/tests/elections/test_uk_parliament.py
+++ b/tests/elections/test_uk_parliament.py
@@ -1,3 +1,4 @@
+import pytest
 from datetime import date
 
 from uk_election_timetables.calendars import Country
@@ -44,3 +45,16 @@ def test_postal_vote_application_deadline_uk_parliament_2019():
     election = UKParliamentElection(date(2019, 12, 12))
 
     assert election.postal_vote_application_deadline == date(2019, 11, 26)
+
+
+@pytest.mark.parametrize(
+    "country, deadline_date",
+    [
+        (Country.ENGLAND, date(2023, 4, 3)),
+        (Country.SCOTLAND, date(2023, 4, 4)),  # No Easter Monday BH in Scotland
+        (Country.WALES, date(2023, 4, 3)),
+    ],
+)
+def test_vac_application_deadline_uk_parliament(country, deadline_date):
+    election = UKParliamentElection(date(2023, 4, 13), country=country)
+    assert election.vac_application_deadline == deadline_date

--- a/tests/test_election.py
+++ b/tests/test_election.py
@@ -17,40 +17,50 @@ def test_timetable_sopn_publish_date():
 def test_timetable_registration_deadline():
     election = from_election_id("local.2021-05-06", country=Country.ENGLAND)
 
-    sopn_publish_date = lookup(election, "Register to vote deadline")
+    electoral_registration_deadline = lookup(election, "Register to vote deadline")
 
-    assert sopn_publish_date["date"] == date(2021, 4, 19)
+    assert electoral_registration_deadline["date"] == date(2021, 4, 19)
 
 
 def test_timetable_postal_vote_application_deadline():
     election = from_election_id("local.2021-05-06", country=Country.ENGLAND)
 
-    sopn_publish_date = lookup(election, "Postal vote application deadline")
+    postal_vote_dealine = lookup(election, "Postal vote application deadline")
 
-    assert sopn_publish_date["date"] == date(2021, 4, 20)
+    assert postal_vote_dealine["date"] == date(2021, 4, 20)
+
+
+def test_timetable_vac_application_deadline():
+    election = from_election_id("parl.2023-05-04", country=Country.ENGLAND)
+
+    vac_deadline = lookup(election, "VAC application deadline")
+
+    assert vac_deadline["date"] == date(2023, 4, 25)
 
 
 def test_timetable_sort_order():
     election = from_election_id("local.2021-05-06", country=Country.ENGLAND)
 
-    assert len(election.timetable) == 3
+    assert len(election.timetable) == 4
 
-    assert [r["date"] for r in election.timetable] == [
-        date(2021, 4, 9),
-        date(2021, 4, 19),
-        date(2021, 4, 20),
+    assert election.timetable == [
+        {"label": "List of candidates published", "date": date(2021, 4, 9)},
+        {"label": "Register to vote deadline", "date": date(2021, 4, 19)},
+        {"label": "Postal vote application deadline", "date": date(2021, 4, 20)},
+        {"label": "VAC application deadline", "date": date(2021, 4, 27)},
     ]
 
 
 def test_timetable_sort_order_scottish_parliament_postal_vote():
     election = from_election_id("sp.c.2021-05-06")
 
-    assert len(election.timetable) == 3
+    assert len(election.timetable) == 4
 
-    assert [r["date"] for r in election.timetable] == [
-        date(2021, 4, 1),
-        date(2021, 4, 6),
-        date(2021, 4, 19),
+    assert election.timetable == [
+        {"label": "List of candidates published", "date": date(2021, 4, 1)},
+        {"label": "Postal vote application deadline", "date": date(2021, 4, 6)},
+        {"label": "Register to vote deadline", "date": date(2021, 4, 19)},
+        {"label": "VAC application deadline", "date": date(2021, 4, 27)},
     ]
 
 

--- a/uk_election_timetables/election.py
+++ b/uk_election_timetables/election.py
@@ -28,6 +28,17 @@ class Election(metaclass=ABCMeta):
         return working_days_before(self.poll_date, 11, self._calendar())
 
     @property
+    def vac_application_deadline(self) -> date:
+        """
+        Calculates the Voter Authority Certificate (VAC) application deadline for this Election
+
+        This is set out by the Electoral Commission here: https://www.electoralcommission.org.uk/cy/node/25624
+
+        :return: datetime.date representing the VAC application deadline
+        """
+        return working_days_before(self.poll_date, 6, self._calendar())
+
+    @property
     @abstractmethod
     def sopn_publish_date(self) -> date:
         pass
@@ -63,6 +74,10 @@ class Election(metaclass=ABCMeta):
                 {
                     "label": "Postal vote application deadline",
                     "date": self.postal_vote_application_deadline,
+                },
+                {
+                    "label": "VAC application deadline",
+                    "date": self.vac_application_deadline,
                 },
             ],
             key=lambda r: r["date"],


### PR DESCRIPTION
Closes #18 

This adds a VAC deadline to all elections, set to 6 working days before the election date. This work doesn't exclude NI or other elections which won't require ID in the form of a VAC as this project hasn't yet been updated to reflect the new legislation.

Updated some of the existing tests to include the new field and improve clarity, plus a couple of new tests specifically for VAC calculation.