### PR TITLE
Change NI to 14 day postal vote reg deadline

### DIFF
--- a/tests/elections/test_local.py
+++ b/tests/elections/test_local.py
@@ -37,3 +37,12 @@ def test_postal_vote_application_deadline_local_election_england():
     election = LocalElection(date(2021, 5, 6), country=Country.ENGLAND)
 
     assert election.postal_vote_application_deadline == date(2021, 4, 20)
+
+
+# Reference election: local.belfast.2023-05-18
+def test_postal_vote_application_deadline_local_election_northern_ireland():
+    deadline = LocalElection(
+        date(2023, 5, 18), country=Country.NORTHERN_IRELAND
+    ).postal_vote_application_deadline
+
+    assert deadline == date(2023, 4, 26)

--- a/uk_election_timetables/election.py
+++ b/uk_election_timetables/election.py
@@ -23,8 +23,13 @@ class Election(metaclass=ABCMeta):
 
         This is set out in `The Representation of the People (England and Wales) Regulations 2001 <https://www.legislation.gov.uk/uksi/2001/341/regulation/56/made>`_.
 
+        In Northern Ireland, this is set out in `The Representation of the People (Northern Ireland) Regulations 2008 <https://www.legislation.gov.uk/uksi/2008/1741/regulation/61/made>`
+
         :return: a datetime representing the postal vote application deadline
         """
+        if self.country == Country.NORTHERN_IRELAND:
+            return working_days_before(self.poll_date, 14, self._calendar())
+
         return working_days_before(self.poll_date, 11, self._calendar())
 
     @property


### PR DESCRIPTION
[Asana](https://app.asana.com/0/1204880927741389/1205127306104503)

NI updated their legislation in 2008 to set their deadline for postal vote applications to be 14 working days before an election. We weren't aware of this legislation so we had been incorrectly reporting the deadline as 11 working days on Northern Irish elections.

[Legislation](https://www.legislation.gov.uk/uksi/2008/1741/regulation/61/made)

```[tasklist]
- [x] References a specific issue or if not, describes the bug or feature in detail
- [x] Note what card in Asana this work relates to
- [x] Tests have been added and/or updated
```
