### PR TITLE
drop testing on python < 3.10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
           command: ruff check .
       - run:
           name: Ruff Format
-          command: ruff format .
+          command: ruff format . --check
       - run:
           name: Run tests
           command: pytest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ workflows:
       - build-and-test:
           matrix:
             parameters:
-              python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
+              python-version: [ "3.10", "3.11", "3.12" ]
 
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # uk-election-timetables
 
-[![Build Status](https://travis-ci.com/DemocracyClub/uk-election-timetables.svg?branch=main)](https://travis-ci.com/DemocracyClub/uk-election-timetables)
+[![CircleCI](https://dl.circleci.com/status-badge/img/gh/DemocracyClub/uk-election-timetables/tree/main.svg?style=svg)](https://dl.circleci.com/status-badge/redirect/gh/DemocracyClub/uk-election-timetables/tree/main)
 [![Documentation Status](https://readthedocs.org/projects/uk-election-timetables/badge/?version=latest)](https://uk-election-timetables.readthedocs.io/en/latest/overview.html?badge=latest)
 [![PyPI](https://img.shields.io/pypi/v/uk-election-timetables.svg)](https://pypi.org/project/uk-election-timetables/)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)


### PR DESCRIPTION
Came to this repo to do the usual maintenance tasks. Turns out, this repo was already in pretty good shape. It has a working CI build, we had already adopted ruff, we're already running the tests on python 3.12. There's not much to do here. Just a few bits of tidyup.