### PR TITLE
fix incorrect docstrings

### DIFF
--- a/uk_election_timetables/elections/greater_london_assembly.py
+++ b/uk_election_timetables/elections/greater_london_assembly.py
@@ -6,6 +6,9 @@ from uk_election_timetables.election import Election
 
 class GreaterLondonAssemblyElection(Election):
     def __init__(self, poll_date: date):
+        """
+        :param poll_date: a datetime representing the date of the poll
+        """
         Election.__init__(self, poll_date, Country.ENGLAND)
 
     @property
@@ -15,7 +18,6 @@ class GreaterLondonAssemblyElection(Election):
 
         This is set out in `The Greater London Authority Elections (Amendment) Rules 2016 <https://www.legislation.gov.uk/uksi/2016/24/article/6/made>`_
 
-        :param poll_date: a datetime representing the date of the poll
         :return: a datetime representing the expected publish date
         """
         return working_days_before(self.poll_date, 22, super()._calendar())

--- a/uk_election_timetables/elections/local.py
+++ b/uk_election_timetables/elections/local.py
@@ -16,8 +16,6 @@ class LocalElection(Election):
          * `The Local Elections (Northern Ireland) Order 2010 <https://www.legislation.gov.uk/uksi/2010/2977/schedule/1/part/4/made>`_
          * `The Scottish Local Government Elections Order 2011 <https://www.legislation.gov.uk/ssi/2011/399/made>`_
 
-        :param poll_date: a datetime representing the date of the poll
-        :param country: the country in which the election is being run
         :return: a datetime representing the expected publish date
         """
 

--- a/uk_election_timetables/elections/mayor.py
+++ b/uk_election_timetables/elections/mayor.py
@@ -6,6 +6,9 @@ from uk_election_timetables.election import Election
 
 class MayoralElection(Election):
     def __init__(self, poll_date: date):
+        """
+        :param poll_date: a datetime representing the date of the poll
+        """
         Election.__init__(self, poll_date, Country.ENGLAND)
 
     @property
@@ -15,7 +18,6 @@ class MayoralElection(Election):
 
         This is set out in `The Local Authorities (Mayoral Elections) (England and Wales) (Amendment) Regulations 2014 <https://www.legislation.gov.uk/uksi/2014/370/made>`_
 
-        :param poll_date: a datetime representing the date of the poll
         :return: a datetime representing the expected publish date
         """
         return working_days_before(self.poll_date, 19, super()._calendar())

--- a/uk_election_timetables/elections/northern_ireland_assembly.py
+++ b/uk_election_timetables/elections/northern_ireland_assembly.py
@@ -6,6 +6,9 @@ from uk_election_timetables.election import Election
 
 class NorthernIrelandAssemblyElection(Election):
     def __init__(self, poll_date: date):
+        """
+        :param poll_date: a datetime representing the date of the poll
+        """
         Election.__init__(self, poll_date, Country.NORTHERN_IRELAND)
 
     @property
@@ -15,7 +18,6 @@ class NorthernIrelandAssemblyElection(Election):
 
         This is set out by Schedule 5, Rules 1 and 2 of `The Northern Ireland Assembly (Elections) (Amendment) Order 2009 <https://www.legislation.gov.uk/uksi/2009/256/made>`_
 
-        :param poll_date: a datetime representing the date of the poll
         :return: a datetime representing the expected publish date
         """
         return working_days_before(self.poll_date, 16, super()._calendar())

--- a/uk_election_timetables/elections/police_and_crime_commissioner.py
+++ b/uk_election_timetables/elections/police_and_crime_commissioner.py
@@ -6,6 +6,9 @@ from uk_election_timetables.election import Election
 
 class PoliceAndCrimeCommissionerElection(Election):
     def __init__(self, poll_date: date):
+        """
+        :param poll_date: a datetime representing the date of the poll
+        """
         Election.__init__(self, poll_date, Country.ENGLAND)
 
     @property
@@ -15,7 +18,6 @@ class PoliceAndCrimeCommissionerElection(Election):
 
         This is set out in `The Police and Crime Commissioner Elections (Amendment) Order 2014 <https://www.legislation.gov.uk/uksi/2014/921/article/31/made>`_
 
-        :param poll_date: a datetime representing the date of the poll
         :return: a datetime representing the expected publish date
         """
         return working_days_before(self.poll_date, 18, super()._calendar())

--- a/uk_election_timetables/elections/scottish_parliament.py
+++ b/uk_election_timetables/elections/scottish_parliament.py
@@ -6,6 +6,9 @@ from uk_election_timetables.election import Election
 
 class ScottishParliamentElection(Election):
     def __init__(self, poll_date: date):
+        """
+        :param poll_date: a datetime representing the date of the poll
+        """
         Election.__init__(self, poll_date, Country.SCOTLAND)
 
     @property
@@ -30,7 +33,6 @@ class ScottishParliamentElection(Election):
 
         This is set out in `The Scottish Parliament (Elections etc.) Order 2015 <https://www.legislation.gov.uk/ssi/2015/425/made>`_
 
-        :param poll_date: a datetime representing the date of the poll
         :return: a datetime representing the expected publish date
         """
         return working_days_before(self.poll_date, 23, super()._calendar())

--- a/uk_election_timetables/elections/senedd_cymru.py
+++ b/uk_election_timetables/elections/senedd_cymru.py
@@ -6,6 +6,9 @@ from uk_election_timetables.election import Election
 
 class SeneddCymruElection(Election):
     def __init__(self, poll_date: date):
+        """
+        :param poll_date: a datetime representing the date of the poll
+        """
         Election.__init__(self, poll_date, Country.WALES)
 
     @property
@@ -15,7 +18,6 @@ class SeneddCymruElection(Election):
 
         This is set out in `Senedd and Elections (Wales) Act 2020 <https://www.legislation.gov.uk/anaw/2020/1/contents>` and `The National Assembly for Wales (Representation of the People) (Amendment) Order 2016 <https://www.legislation.gov.uk/uksi/2016/272/article/18/made>`_
 
-        :param poll_date: a datetime representing the date of the poll
         :return: a datetime representing the expected publish date
         """
         return working_days_before(self.poll_date, 19, super()._calendar())

--- a/uk_election_timetables/elections/uk_parliament.py
+++ b/uk_election_timetables/elections/uk_parliament.py
@@ -6,6 +6,10 @@ from uk_election_timetables.election import Election
 
 class UKParliamentElection(Election):
     def __init__(self, poll_date: date, country: Country = None):
+        """
+        :param poll_date: a datetime representing the date of the poll
+        :param country: an optional Country representing the country where the election will be held
+        """
         Election.__init__(self, poll_date, country)
 
     @property
@@ -15,8 +19,6 @@ class UKParliamentElection(Election):
 
         This is set out in `Representation of the People Act 1983 <https://www.legislation.gov.uk/ukpga/1983/2/contents>`_ and its amendments.
 
-        :param poll_date: a datetime representing the date of the poll
-        :param country: an optional Country representing the country where the election will be held
         :return: a datetime representing the expected publish date
         """
 


### PR DESCRIPTION
While I was working on this I noticed that most of the docstrings for `sopn_publish_date()` functions are wrong.

I assume this is copy and paste from some previous time when they were standalone functions