### PR TITLE
Add CityOfLondonLocalElection class

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Hosted by readthedocs at [https://uk-election-timetables.readthedocs.io/](https:
 ## Supported Election Types
 
  - [x] Local
+ - [x] City of London Local
  - [x] United Kingdom Parliament
  - [x] Scottish Parliament
  - [x] Senedd Cymru

--- a/docs/elections.rst
+++ b/docs/elections.rst
@@ -20,6 +20,14 @@ elections.local
    :undoc-members:
    :show-inheritance:
 
+elections.city\_of\_london\_local
+----------------------
+
+.. automodule:: uk_election_timetables.elections.city_of_london_local
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 elections.mayor
 ----------------------
 

--- a/tests/elections/test_city_of_london_local.py
+++ b/tests/elections/test_city_of_london_local.py
@@ -1,0 +1,31 @@
+from datetime import date
+
+import pytest
+from uk_election_timetables.elections import CityOfLondonLocalElection
+
+registration_test_cases = [
+    {
+        "poll_date": date(2025, 1, 1),
+        "expected_registration_deadline": date(2023, 11, 30),
+    },
+    {
+        "poll_date": date(2025, 2, 15),
+        "expected_registration_deadline": date(2023, 11, 30),
+    },
+    {
+        "poll_date": date(2025, 2, 16),
+        "expected_registration_deadline": date(2024, 11, 30),
+    },
+    {
+        "poll_date": date(2025, 11, 29),
+        "expected_registration_deadline": date(2024, 11, 30),
+    },
+]
+
+
+@pytest.mark.parametrize("election", registration_test_cases)
+def test_city_of_london_registration_deadline(election):
+    assert (
+        CityOfLondonLocalElection(election["poll_date"]).registration_deadline
+        == election["expected_registration_deadline"]
+    )

--- a/tests/test_election.py
+++ b/tests/test_election.py
@@ -1,10 +1,12 @@
 import datetime
 from typing import Dict
+import pytest
 
 from uk_election_timetables.calendars import Country
 from uk_election_timetables.election import Election, TimetableEvent
 
 from uk_election_timetables.election_ids import from_election_id
+from uk_election_timetables import elections
 
 
 def test_timetable_sopn_publish_date():
@@ -141,3 +143,78 @@ def test_is_after():
     assert election.is_after(TimetableEvent.SOPN_PUBLISH_DATE) is True
     assert election.is_after(TimetableEvent.POSTAL_VOTE_APPLICATION_DEADLINE) is True
     assert election.is_after(TimetableEvent.VAC_APPLICATION_DEADLINE) is True
+
+
+election_types = [
+    {
+        "election_id": "nia.2019-02-21",
+        "country": None,
+        "expected_type": elections.NorthernIrelandAssemblyElection,
+    },
+    {
+        "election_id": "naw.2019-02-21",
+        "country": None,
+        "expected_type": elections.SeneddCymruElection,
+    },
+    {
+        "election_id": "senedd.2019-02-21",
+        "country": None,
+        "expected_type": elections.SeneddCymruElection,
+    },
+    {
+        "election_id": "gla.2019-02-21",
+        "country": None,
+        "expected_type": elections.GreaterLondonAssemblyElection,
+    },
+    {
+        "election_id": "pcc.2019-02-21",
+        "country": None,
+        "expected_type": elections.PoliceAndCrimeCommissionerElection,
+    },
+    {
+        "election_id": "mayor.2019-02-21",
+        "country": None,
+        "expected_type": elections.MayoralElection,
+    },
+    # City of London
+    {
+        "election_id": "local.city-of-london.2019-02-21",  # Common Council
+        "country": None,
+        "expected_type": elections.CityOfLondonLocalElection,
+    },
+    {
+        "election_id": "local.city-of-london-alder.2019-02-21",  # Aldermen
+        "country": None,
+        "expected_type": elections.CityOfLondonLocalElection,
+    },
+    # local
+    {
+        "election_id": "local.somewhere.2019-02-21",
+        "country": Country.ENGLAND,
+        "expected_type": elections.LocalElection,
+    },
+    {
+        "election_id": "local.somewhere.2019-02-21",
+        "country": Country.WALES,
+        "expected_type": elections.LocalElection,
+    },
+    # parl
+    {
+        "election_id": "parl.somewhere.2019-02-21",
+        "country": Country.ENGLAND,
+        "expected_type": elections.UKParliamentElection,
+    },
+    {
+        "election_id": "parl.somewhere.2019-02-21",
+        "country": Country.WALES,
+        "expected_type": elections.UKParliamentElection,
+    },
+]
+
+
+@pytest.mark.parametrize("election", election_types)
+def test_from_election_types_types(election):
+    assert isinstance(
+        from_election_id(election["election_id"], election["country"]),
+        election["expected_type"],
+    )

--- a/uk_election_timetables/election_ids.py
+++ b/uk_election_timetables/election_ids.py
@@ -12,6 +12,7 @@ from uk_election_timetables.elections import (
     PoliceAndCrimeCommissionerElection,
     MayoralElection,
     LocalElection,
+    CityOfLondonLocalElection,
     UKParliamentElection,
 )
 
@@ -100,6 +101,10 @@ def from_election_id(election_id: str, country: Country = None) -> Election:
 
     if not valid_election_type(election_type):
         raise NoSuchElectionTypeError(election_type)
+
+    if election_id.startswith("local.city-of-london"):
+        # The City of London is special and different
+        return CityOfLondonLocalElection(poll_date)
 
     if requires_country(election_type) and country is None:
         raise AmbiguousElectionIdError(election_id)

--- a/uk_election_timetables/elections/__init__.py
+++ b/uk_election_timetables/elections/__init__.py
@@ -9,6 +9,9 @@ from uk_election_timetables.elections.northern_ireland_assembly import (
     NorthernIrelandAssemblyElection,
 )
 from uk_election_timetables.elections.local import LocalElection
+from uk_election_timetables.elections.city_of_london_local import (
+    CityOfLondonLocalElection,
+)
 from uk_election_timetables.elections.uk_parliament import UKParliamentElection
 from uk_election_timetables.elections.police_and_crime_commissioner import (
     PoliceAndCrimeCommissionerElection,
@@ -21,6 +24,7 @@ __ALL__ = (
     GreaterLondonAssemblyElection,
     NorthernIrelandAssemblyElection,
     LocalElection,
+    CityOfLondonLocalElection,
     UKParliamentElection,
     PoliceAndCrimeCommissionerElection,
     MayoralElection,

--- a/uk_election_timetables/elections/city_of_london_local.py
+++ b/uk_election_timetables/elections/city_of_london_local.py
@@ -1,0 +1,37 @@
+from datetime import date
+
+from uk_election_timetables.calendars import working_days_before, Country
+from uk_election_timetables.election import Election
+
+
+"""
+TODO:
+This is insufficently nuanced
+https://github.com/DemocracyClub/uk-election-timetables/issues/8
+"""
+
+
+class CityOfLondonLocalElection(Election):
+    def __init__(self, poll_date: date):
+        Election.__init__(self, poll_date, Country.ENGLAND)
+
+    @property
+    def sopn_publish_date(self) -> date:
+        """
+        Calculate the SOPN publish date for a City of London local election.
+
+        :return: a datetime representing the expected publish date
+        """
+
+        return working_days_before(self.poll_date, 17, super()._calendar())
+
+    @property
+    def registration_deadline(self) -> date:
+        """
+        Calculates the voter registration deadline for a City of London local election.
+
+        :return: a datetime representing the voter registration deadline
+        """
+        if self.poll_date <= date(self.poll_date.year, 2, 15):
+            return date(self.poll_date.year - 2, 11, 30)
+        return date(self.poll_date.year - 1, 11, 30)

--- a/uk_election_timetables/elections/city_of_london_local.py
+++ b/uk_election_timetables/elections/city_of_london_local.py
@@ -13,6 +13,9 @@ https://github.com/DemocracyClub/uk-election-timetables/issues/8
 
 class CityOfLondonLocalElection(Election):
     def __init__(self, poll_date: date):
+        """
+        :param poll_date: a datetime representing the date of the poll
+        """
         Election.__init__(self, poll_date, Country.ENGLAND)
 
     @property


### PR DESCRIPTION
Refs https://app.asana.com/0/1204880927741389/1208540419887296/f
Refs https://github.com/DemocracyClub/uk-election-timetables/issues/8

OK. This is a bit of an odd opening gambit for a PR, but here goes:
This code isn't really right..
..but also I think we should merge it.

To expand on that a bit:

I started looking at making changes to the client apps first and I quickly realised that having a correct (or more correct) `registration_deadline` in this package would actually make things a lot easier. So I decided to start here (even though that wasn't my original plan).

Currently, our timetable for City of London Elections is wrong in several ways.
In this PR, I have added a special `CityOfLondonLocalElection` class and the logic to return it if given a CoL local election ID. However, this is still probably a bit wrong and definitely improperly sourced (usually in this library, everything is tied back to legislation) That said, it is closer to correct than what we're doing now.

So my suggestion is we merge this and put out a release on the basis it is better than what we're doing now and then work on improving it.