### PR TITLE
implement special rules for City of London SOPN date

### DIFF
--- a/tests/elections/test_city_of_london_local.py
+++ b/tests/elections/test_city_of_london_local.py
@@ -1,7 +1,13 @@
-from datetime import date
+from datetime import date, datetime
 
 import pytest
+from uk_election_timetables.calendars import Country, UnitedKingdomBankHolidays
 from uk_election_timetables.elections import CityOfLondonLocalElection
+from uk_election_timetables.elections.city_of_london_local import (
+    _get_christmas_break,
+    _get_easter_break,
+)
+
 
 registration_test_cases = [
     {
@@ -29,3 +35,101 @@ def test_city_of_london_registration_deadline(election):
         CityOfLondonLocalElection(election["poll_date"]).registration_deadline
         == election["expected_registration_deadline"]
     )
+
+
+sopn_test_cases = [
+    {
+        # https://candidates.democracyclub.org.uk/elections/local.city-of-london.cordwainer.by.2022-09-15/sopn/
+        "poll_date": date(2022, 9, 15),
+        "sopn_publish_date": date(2022, 8, 23),
+    },
+    {
+        # https://candidates.democracyclub.org.uk/elections/local.city-of-london.bassishaw.by.2019-04-30/sopn/
+        # includes an easter break
+        "poll_date": date(2019, 4, 30),
+        "sopn_publish_date": date(2019, 4, 2),
+    },
+    {
+        # https://candidates.democracyclub.org.uk/elections/local.city-of-london-alder.cornhill.2022-05-26/sopn/
+        "poll_date": date(2022, 5, 26),
+        "sopn_publish_date": date(2022, 5, 4),
+    },
+]
+
+
+@pytest.mark.parametrize("election", sopn_test_cases)
+def test_city_of_london_sopn_date(election):
+    assert (
+        CityOfLondonLocalElection(election["poll_date"]).sopn_publish_date
+        == election["sopn_publish_date"]
+    )
+
+
+def test_get_easter_break():
+    # The main thing we're asserting here is that we've got matchers objects
+    # for each year. If there were some future year where Good Friday wasn't
+    # labelled with "Good Friday" in the gov.uk data, we'd have zero matchers
+    # for that year. this test would catch it and fail.
+    easter_break_matchers = _get_easter_break(
+        UnitedKingdomBankHolidays().from_country(Country.ENGLAND)._bank_holidays
+    )
+    beginning_of_time = 2012
+    current_year = datetime.now().year
+    for year in range(beginning_of_time, current_year + 1):
+        assert (
+            len([matcher for matcher in easter_break_matchers if matcher.year == year])
+            == 6
+        )
+
+
+def _contains_matcher_for_date(matchers, date):
+    return (
+        len(
+            [
+                matcher
+                for matcher in matchers
+                if (matcher.year, matcher.month, matcher.day)
+                == (date.year, date.month, date.day)
+            ]
+        )
+        == 1
+    )
+
+
+def test_get_christmas_break_2014():
+    # In 2014, Christmas and Boxing day are Friday and Sturday
+    # The next available weekday is Monday 29th
+    christmas_break_matchers = _get_christmas_break(
+        UnitedKingdomBankHolidays().from_country(Country.ENGLAND)._bank_holidays
+    )
+    assert _contains_matcher_for_date(christmas_break_matchers, date(2014, 12, 24))
+    assert _contains_matcher_for_date(christmas_break_matchers, date(2014, 12, 29))
+
+
+def test_get_christmas_break_2021():
+    # In 2021, Christmas and Boxing day both fall at the weekend
+    # with substitute bank holidays on the 27th and 28th
+    christmas_break_matchers = _get_christmas_break(
+        UnitedKingdomBankHolidays().from_country(Country.ENGLAND)._bank_holidays
+    )
+    assert _contains_matcher_for_date(christmas_break_matchers, date(2021, 12, 24))
+    assert _contains_matcher_for_date(christmas_break_matchers, date(2021, 12, 29))
+
+
+def test_get_christmas_break_2022():
+    # In 2022, Christmas day falls on Sunday
+    # with a substitute bank holiday on the 27th
+    christmas_break_matchers = _get_christmas_break(
+        UnitedKingdomBankHolidays().from_country(Country.ENGLAND)._bank_holidays
+    )
+    assert _contains_matcher_for_date(christmas_break_matchers, date(2022, 12, 23))
+    assert _contains_matcher_for_date(christmas_break_matchers, date(2022, 12, 28))
+
+
+def test_get_christmas_break_2024():
+    # In 2024, Christmas Eve, Christmas Day, Boxing day and the 27th are all weekdays
+    christmas_break_matchers = _get_christmas_break(
+        UnitedKingdomBankHolidays().from_country(Country.ENGLAND)._bank_holidays
+    )
+    assert _contains_matcher_for_date(christmas_break_matchers, date(2024, 12, 24))
+    assert _contains_matcher_for_date(christmas_break_matchers, date(2024, 12, 27))

--- a/uk_election_timetables/calendars.py
+++ b/uk_election_timetables/calendars.py
@@ -38,7 +38,7 @@ class Region(Enum):
 
 class BankHolidayCalendar:
     """
-    A calendar that honours the standard 5-day week in addition to the input list of dates.
+    A calendar that excludes the input list of dates.
     """
 
     @staticmethod
@@ -46,7 +46,10 @@ class BankHolidayCalendar:
         event_date = datetime.strptime(entry["date"], "%Y-%m-%d")
 
         return DateMatcher(
-            year=event_date.year, month=event_date.month, day=event_date.day
+            name=entry["title"],
+            year=event_date.year,
+            month=event_date.month,
+            day=event_date.day,
         )
 
     def __init__(self, dates):
@@ -56,9 +59,9 @@ class BankHolidayCalendar:
             BankHolidayCalendar.create_matcher_from_entry(entry) for entry in dates
         ]
 
-        days_not_counted.append(christmas_eve)
+        self._bank_holidays = days_not_counted
 
-        self._exempted_dates = days_not_counted
+        self._exempted_dates = self._bank_holidays + [christmas_eve]
 
     def exempted_dates(self):
         return self._exempted_dates

--- a/uk_election_timetables/date.py
+++ b/uk_election_timetables/date.py
@@ -3,6 +3,7 @@ from datetime import date, timedelta
 
 SATURDAY = 5
 SUNDAY = 6
+WEEKEND = [SATURDAY, SUNDAY]
 
 
 class DateMatcher:
@@ -49,7 +50,7 @@ def days_before(poll_date: date, days: int, ignore: List[DateMatcher] = None) ->
     while days > 0:
         poll_date -= timedelta(days=1)
 
-        if poll_date.weekday() in [SATURDAY, SUNDAY]:
+        if poll_date.weekday() in WEEKEND:
             continue
 
         if ignore and any([day.matches(poll_date) for day in ignore]):

--- a/uk_election_timetables/elections/city_of_london_local.py
+++ b/uk_election_timetables/elections/city_of_london_local.py
@@ -1,14 +1,82 @@
-from datetime import date
+from datetime import date, datetime, timedelta
+from typing import List
 
-from uk_election_timetables.calendars import working_days_before, Country
+from uk_election_timetables.calendars import (
+    working_days_before,
+    Country,
+    UnitedKingdomBankHolidays,
+)
+from uk_election_timetables.date import DateMatcher, WEEKEND
 from uk_election_timetables.election import Election
 
 
-"""
-TODO:
-This is insufficently nuanced
-https://github.com/DemocracyClub/uk-election-timetables/issues/8
-"""
+def _is_bank_holiday(date: date, bank_holidays: List[DateMatcher]) -> bool:
+    for bh in bank_holidays:
+        if bh.matches(date):
+            return True
+    return False
+
+
+def _get_easter_break(bank_holidays: List[DateMatcher]) -> List[DateMatcher]:
+    """
+    “the Easter break” means the period beginning with the Thursday before
+    and ending with the Tuesday after Easter Day
+
+    Fortunately the Gov.UK bank holidays are consistently labelled
+    """
+    easter_break = []
+    for bh in bank_holidays:
+        if bh.name == "Good Friday":
+            good_friday = date(bh.year, bh.month, bh.day)
+            for offset in range(-1, 5):
+                day = good_friday + timedelta(days=offset)
+                easter_break.append(
+                    DateMatcher(
+                        name="City of London Easter Break",
+                        year=day.year,
+                        month=day.month,
+                        day=day.day,
+                    )
+                )
+    return easter_break
+
+
+def _get_christmas_break(bank_holidays: List[DateMatcher]) -> List[DateMatcher]:
+    """
+    “the Christmas break” means the period beginning with the last week day
+    before Christmas Day and ending with the first week day after Christmas
+    Day which is not a bank holiday
+    """
+    christmas_break = []
+
+    # 2012 is the first year that exists in our bank holiday calendar
+    # so we won't go any further back than that
+    beginning_of_time = 2012
+    current_year = datetime.now().year
+
+    for year in range(beginning_of_time, current_year + 1):
+        break_start = date(year, 12, 24)
+        while break_start.weekday() in WEEKEND:
+            break_start -= timedelta(days=1)
+
+        break_end = date(year, 12, 27)
+        while break_end.weekday() in WEEKEND or _is_bank_holiday(
+            break_end, bank_holidays
+        ):
+            break_end += timedelta(days=1)
+
+        current_date = break_start
+        while current_date <= break_end:
+            christmas_break.append(
+                DateMatcher(
+                    name="City of London Christmas Break",
+                    year=current_date.year,
+                    month=current_date.month,
+                    day=current_date.day,
+                )
+            )
+            current_date += timedelta(days=1)
+    return christmas_break
 
 
 class CityOfLondonLocalElection(Election):
@@ -21,12 +89,44 @@ class CityOfLondonLocalElection(Election):
     @property
     def sopn_publish_date(self) -> date:
         """
-        Calculate the SOPN publish date for a City of London local election.
+        Calculate the "SOPN publish date" for a City of London local election.
+
+        There are actually 2 releavant dates here:
+        The SOPN is _published_ **17 (working) days before polling day**
+        but then candidates can be withdrawn from it for an additional day
+        after that.
+        So the SOPN becomes _final_ **16 (working) days before polling day**
+
+        For the sake of simplicity, we are going to call 16 days before
+        polling day the "sopn_publish_date".
+
+        As well as the usual exclusions for weekends and bank holidays,
+        the City of London also exclude a Christmas break and Easter break.
+
+        In this section “the Christmas break” means the period beginning with
+        the last week day before Christmas Day and ending with the first week
+        day after Christmas Day which is not a bank holiday; “the Easter break”
+        means the period beginning with the Thursday before and ending with the
+        Tuesday after Easter Day;
 
         :return: a datetime representing the expected publish date
         """
 
-        return working_days_before(self.poll_date, 17, super()._calendar())
+        # Make a new calendar object so we don't mutate
+        # the shared England & Wales calendar
+        calendar = UnitedKingdomBankHolidays().from_country(Country.ENGLAND)
+
+        # Add the City of London Christmas and Easter breaks
+        # This will result in some duplication in _exempted_dates
+        # where existing bank holidays are also inside these intervals
+        # but this doesn't really matter
+        calendar._exempted_dates = (
+            calendar._exempted_dates
+            + _get_easter_break(calendar._bank_holidays)
+            + _get_christmas_break(calendar._bank_holidays)
+        )
+
+        return working_days_before(self.poll_date, 16, calendar)
 
     @property
     def registration_deadline(self) -> date:


### PR DESCRIPTION
Closes https://github.com/DemocracyClub/uk-election-timetables/issues/8

In this PR, I have implemented correct rules for working out City of London's SOPN dates

I think the code comments explain this quite fully so I'm not going to duplicate them here.

One thing I will note is: There was some discussion in https://github.com/DemocracyClub/uk-election-timetables/issues/8 indicating that Saturday might be considered a "working day" for City of London's timetable, but I took a bunch of examples of real elections and based on polling day/SOPN published date, I think both Saturdays and Sundays are excluded as normal. So really it just boils down to implementing the City of London's Christmas and Easter breaks.

Out of scope for this PR is: Currently we return a VAC deadline for elections where ID is not required. Doing anything about that is another PR. This one is only about implementing City of London's SOPN rules.