### PR TITLE
throw errors from update script

### DIFF
--- a/manage_bank_holidays.py
+++ b/manage_bank_holidays.py
@@ -22,18 +22,11 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     if args.diff:
-        try:
-            additions_count: int = diff_bank_holidays()
-            print(f"No. of additions: {additions_count}")
-            sys.exit(additions_count)
-        except Exception:
-            print("Unable to diff files")
-            sys.exit(0)
+        additions_count: int = diff_bank_holidays()
+        print(f"No. of additions: {additions_count}")
+        sys.exit(additions_count)
     elif args.update:
-        try:
-            update_bank_holidays()
-            print("Update complete")
-        except Exception as ex:
-            print(f"Unable to update bank-holidays.json: {ex}")
+        update_bank_holidays()
+        print("Update complete")
     else:
         print("No action provided. Check --help for a list of actions.")


### PR DESCRIPTION
If this fails, currently it is set to swallow the error and exit with code zero. I want it to throw an exception so we know it happened and we can go fix it.
