### PR TITLE
Prevent City of London special cases from mutating the England calendar

### DIFF
--- a/tests/elections/test_city_of_london_local.py
+++ b/tests/elections/test_city_of_london_local.py
@@ -103,7 +103,7 @@ def _contains_matcher_for_date(matchers, date):
 
 
 def test_get_christmas_break_2014():
-    # In 2014, Christmas and Boxing day are Friday and Sturday
+    # In 2014, Christmas and Boxing day are Friday and Saturday
     # The next available weekday is Monday 29th
     christmas_break_matchers = _get_christmas_break(
         UnitedKingdomBankHolidays().from_country(Country.ENGLAND)._bank_holidays

--- a/tests/test_election.py
+++ b/tests/test_election.py
@@ -236,3 +236,19 @@ def test_from_election_types_types(election):
         from_election_id(election["election_id"], election["country"]),
         election["expected_type"],
     )
+
+
+def test_city_of_london_does_not_mutate_global_calendar():
+    assert from_election_id(
+        "mayor.doncaster.2025-05-01", Country.ENGLAND
+    ).sopn_publish_date == datetime.date(2025, 4, 2)
+
+    assert from_election_id(
+        "local.city-of-london.aldersgate.2025-03-20", Country.ENGLAND
+    ).sopn_publish_date == datetime.date(2025, 2, 26)
+
+    # calculating the date for a City of London election
+    # shouldn't change this result
+    assert from_election_id(
+        "mayor.doncaster.2025-05-01", Country.ENGLAND
+    ).sopn_publish_date == datetime.date(2025, 4, 2)

--- a/uk_election_timetables/calendars.py
+++ b/uk_election_timetables/calendars.py
@@ -75,9 +75,9 @@ class UnitedKingdomBankHolidays(object):
     This class exposes a function for each unique calendar: England & Wales, Northern Ireland, and Scotland.
     """
 
-    _calendar = {}
-
     def __init__(self):
+        self._calendar = {}
+
         bank_holiday_json = os.path.join(
             os.path.dirname(__file__), "bank-holidays.json"
         )


### PR DESCRIPTION
Refs https://app.asana.com/0/1204880927741389/1209167759131438/f

OK, so this is your classic python class properties vs object properties bug.

By declaring `_calendar` as a class property, every instance we create of class `UnitedKingdomBankHolidays` shares the same `_calendar` property. So making a new `UnitedKingdomBankHolidays` object in `CityOfLondonLocalElection.sopn_publish_date()` was not having the desired effect.

For the moment, I've decided to just leave everything else the same. So every `Election` object still shares a single mutable reference to one `UnitedKingdomBankHolidays` object
https://github.com/DemocracyClub/uk-election-timetables/blob/56811d2387db1efdd4000c39287460167eedf328/uk_election_timetables/election.py#L20-L21
I think we can probably restructure things and make this less error prone without having to keep reading and parsing the bank holidays JSON over and over but I decided not to do it in this PR since the fix for this bug is a one-liner.