### PR TITLE
Align sopn_publish_date to close of nominations

### DIFF
--- a/tests/elections/test_local.py
+++ b/tests/elections/test_local.py
@@ -22,7 +22,7 @@ def test_publish_date_northern_ireland_local():
 def test_publish_date_local_election_england():
     election = LocalElection(date(2019, 6, 6), country=Country.ENGLAND)
 
-    assert election.sopn_publish_date == date(2019, 5, 10)
+    assert election.sopn_publish_date == date(2019, 5, 9)
 
 
 # Reference election: local.2021-05-06

--- a/tests/test_election.py
+++ b/tests/test_election.py
@@ -51,7 +51,7 @@ def test_timetable_sort_order():
     assert election.timetable == [
         {
             "label": "List of candidates published",
-            "date": datetime.date(2021, 4, 9),
+            "date": datetime.date(2021, 4, 8),
             "event": "SOPN_PUBLISH_DATE",
         },
         {

--- a/tests/test_election.py
+++ b/tests/test_election.py
@@ -190,9 +190,14 @@ election_types = [
         "expected_type": elections.PoliceAndCrimeCommissionerElection,
     },
     {
-        "election_id": "mayor.2019-02-21",
+        "election_id": "mayor.doncaster.2019-02-21",
         "country": None,
         "expected_type": elections.MayoralElection,
+    },
+    {
+        "election_id": "mayor.london.2019-02-21",
+        "country": None,
+        "expected_type": elections.GreaterLondonAssemblyElection,
     },
     # City of London
     {

--- a/tests/test_sopn_publish_date.py
+++ b/tests/test_sopn_publish_date.py
@@ -31,7 +31,7 @@ def test_publish_date_local_id():
 def test_publish_date_local_id_with_country():
     election = from_election_id("local.2019-02-21", country=Country.ENGLAND)
 
-    assert election.sopn_publish_date == date(2019, 1, 28)
+    assert election.sopn_publish_date == date(2019, 1, 25)
 
 
 def test_publish_date_parl_id_with_country():

--- a/uk_election_timetables/election_ids.py
+++ b/uk_election_timetables/election_ids.py
@@ -97,6 +97,10 @@ def from_election_id(election_id: str, country: Country = None) -> Election:
     def requires_country(el_type):
         return el_type in ["local"]
 
+    if election_id.startswith("mayor.london"):
+        # Mayor of London uses the GLA timetable
+        return GreaterLondonAssemblyElection(poll_date)
+
     if election_id.startswith("local.city-of-london"):
         # The City of London is special and different
         return CityOfLondonLocalElection(poll_date)

--- a/uk_election_timetables/elections/local.py
+++ b/uk_election_timetables/elections/local.py
@@ -20,10 +20,10 @@ class LocalElection(Election):
         """
 
         country_specific_duration = {
-            Country.ENGLAND: 18,
+            Country.ENGLAND: 19,
             Country.NORTHERN_IRELAND: 16,
             Country.SCOTLAND: 23,
-            Country.WALES: 18,
+            Country.WALES: 19,
         }
 
         days_prior = country_specific_duration[self.country]

--- a/uk_election_timetables/elections/mayor.py
+++ b/uk_election_timetables/elections/mayor.py
@@ -16,7 +16,9 @@ class MayoralElection(Election):
         """
         Calculate the publish date for an election to the position of Mayor in England and Wales
 
-        This is set out in `The Local Authorities (Mayoral Elections) (England and Wales) (Amendment) Regulations 2014 <https://www.legislation.gov.uk/uksi/2014/370/made>`_
+        This is set out in
+        - `The Local Authorities (Mayoral Elections) (England and Wales) (Amendment) Regulations 2014 <https://www.legislation.gov.uk/uksi/2014/370/made>`_
+        - `The Combined Authorities (Mayoral Elections) Order 2017 <https://www.legislation.gov.uk/uksi/2017/67/made>`_
 
         :return: a datetime representing the expected publish date
         """


### PR DESCRIPTION
A few of things going on here:

- Unlike LA/CA mayors, Mayor of London uses the GLA calendar. Special-case that
- Align both LA/CA Mayoral Elections and Local Councillor elections to "close of nominations" for sopn_publish_date - 19 days before in both cases
- Update docs

There's a number of other bits of follow up work that come out of this, which I have captured in:

- https://app.asana.com/0/1204880927741389/1209422203495368/f
- https://app.asana.com/0/1204880927741389/1209422203495370/f
- https://app.asana.com/0/1204880927741389/1209431701746166/f
- https://app.asana.com/0/1204880927741389/1209431701746170/f

for another day.

Doing it this way doesn't require any wording updates in WCIVF/YNR/EC site