### PR TITLE
return timetable for referenda

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,4 @@ Hosted by readthedocs at [https://uk-election-timetables.readthedocs.io/](https:
  - [x] Mayoral (London)
  - [x] Greater London Assembly
  - [x] Police and Crime commissioner
+ - [x] Referendum

--- a/docs/elections.rst
+++ b/docs/elections.rst
@@ -52,6 +52,14 @@ elections.police\_and\_crime\_commissioner
    :undoc-members:
    :show-inheritance:
 
+elections.referendum
+-------------------------------------
+
+.. automodule:: uk_election_timetables.elections.referendum
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 elections.scottish\_parliament
 -------------------------------------
 

--- a/tests/test_election.py
+++ b/tests/test_election.py
@@ -101,6 +101,30 @@ def test_timetable_sort_order_scottish_parliament_postal_vote():
     ]
 
 
+def test_timetable_referendum():
+    election = from_election_id("ref.2021-05-06", country=Country.ENGLAND)
+
+    assert len(election.timetable) == 3
+
+    assert election.timetable == [
+        {
+            "label": "Register to vote deadline",
+            "date": datetime.date(2021, 4, 19),
+            "event": "REGISTRATION_DEADLINE",
+        },
+        {
+            "label": "Postal vote application deadline",
+            "date": datetime.date(2021, 4, 20),
+            "event": "POSTAL_VOTE_APPLICATION_DEADLINE",
+        },
+        {
+            "label": "VAC application deadline",
+            "date": datetime.date(2021, 4, 27),
+            "event": "VAC_APPLICATION_DEADLINE",
+        },
+    ]
+
+
 def lookup(election: Election, label: str) -> Dict:
     return next(
         entry for entry in election.timetable if entry["label"] == label
@@ -231,6 +255,17 @@ election_types = [
         "election_id": "parl.somewhere.2019-02-21",
         "country": Country.WALES,
         "expected_type": elections.UKParliamentElection,
+    },
+    # ref
+    {
+        "election_id": "ref.somewhere.2019-02-21",
+        "country": Country.ENGLAND,
+        "expected_type": elections.Referendum,
+    },
+    {
+        "election_id": "ref.somewhere.2019-02-21",
+        "country": Country.WALES,
+        "expected_type": elections.Referendum,
     },
 ]
 

--- a/tests/test_sopn_publish_date.py
+++ b/tests/test_sopn_publish_date.py
@@ -85,6 +85,14 @@ def test_publish_date_senedd_election_id():
     assert election.sopn_publish_date == date(2016, 4, 7)
 
 
+def test_publish_date_referendum():
+    ref = from_election_id("ref.2019-02-21", country=Country.ENGLAND)
+    with raises(NotImplementedError) as err:
+        ref.sopn_publish_date
+
+    assert str(err.value) == "No SOPN date for referenda"
+
+
 def test_christmas_eve_not_counted():
     election_and_expected_sopn_date = {
         PoliceAndCrimeCommissionerElection: date(2018, 12, 11),

--- a/uk_election_timetables/election.py
+++ b/uk_election_timetables/election.py
@@ -1,3 +1,4 @@
+import contextlib
 from abc import ABCMeta, abstractmethod
 from datetime import date, datetime, timezone
 from enum import Enum
@@ -75,31 +76,34 @@ class Election(metaclass=ABCMeta):
         :return: a list representing the entire timetable for this particular election.
         """
 
-        return sorted(
-            [
-                {
-                    "label": TimetableEvent.REGISTRATION_DEADLINE.value,
-                    "date": self.registration_deadline,
-                    "event": TimetableEvent.REGISTRATION_DEADLINE.name,
-                },
+        dates = [
+            {
+                "label": TimetableEvent.REGISTRATION_DEADLINE.value,
+                "date": self.registration_deadline,
+                "event": TimetableEvent.REGISTRATION_DEADLINE.name,
+            },
+            {
+                "label": TimetableEvent.POSTAL_VOTE_APPLICATION_DEADLINE.value,
+                "date": self.postal_vote_application_deadline,
+                "event": TimetableEvent.POSTAL_VOTE_APPLICATION_DEADLINE.name,
+            },
+            {
+                "label": TimetableEvent.VAC_APPLICATION_DEADLINE.value,
+                "date": self.vac_application_deadline,
+                "event": TimetableEvent.VAC_APPLICATION_DEADLINE.name,
+            },
+        ]
+
+        with contextlib.suppress(NotImplementedError):
+            dates.append(
                 {
                     "label": TimetableEvent.SOPN_PUBLISH_DATE.value,
                     "date": self.sopn_publish_date,
                     "event": TimetableEvent.SOPN_PUBLISH_DATE.name,
-                },
-                {
-                    "label": TimetableEvent.POSTAL_VOTE_APPLICATION_DEADLINE.value,
-                    "date": self.postal_vote_application_deadline,
-                    "event": TimetableEvent.POSTAL_VOTE_APPLICATION_DEADLINE.name,
-                },
-                {
-                    "label": TimetableEvent.VAC_APPLICATION_DEADLINE.value,
-                    "date": self.vac_application_deadline,
-                    "event": TimetableEvent.VAC_APPLICATION_DEADLINE.name,
-                },
-            ],
-            key=lambda r: r["date"],
-        )
+                }
+            )
+
+        return sorted(dates, key=lambda r: r["date"])
 
     def _calendar(self):
         return self.BANK_HOLIDAY_CALENDAR.from_country(self.country)

--- a/uk_election_timetables/election_ids.py
+++ b/uk_election_timetables/election_ids.py
@@ -9,6 +9,7 @@ from uk_election_timetables.elections import (
     MayoralElection,
     NorthernIrelandAssemblyElection,
     PoliceAndCrimeCommissionerElection,
+    Referendum,
     ScottishParliamentElection,
     SeneddCymruElection,
     UKParliamentElection,
@@ -95,7 +96,7 @@ def from_election_id(election_id: str, country: Country = None) -> Election:
         ]
 
     def requires_country(el_type):
-        return el_type in ["local"]
+        return el_type in ["local", "ref"]
 
     if election_id.startswith("mayor.london"):
         # Mayor of London uses the GLA timetable
@@ -115,5 +116,7 @@ def from_election_id(election_id: str, country: Country = None) -> Election:
         return LocalElection(poll_date, country)
     if election_type == "parl":
         return UKParliamentElection(poll_date, country)
+    if election_type == "ref":
+        return Referendum(poll_date, country)
 
     raise NoSuchElectionTypeError(election_type)

--- a/uk_election_timetables/elections/__init__.py
+++ b/uk_election_timetables/elections/__init__.py
@@ -12,6 +12,9 @@ from uk_election_timetables.elections.northern_ireland_assembly import (
 from uk_election_timetables.elections.police_and_crime_commissioner import (
     PoliceAndCrimeCommissionerElection,
 )
+from uk_election_timetables.elections.referendum import (
+    Referendum,
+)
 from uk_election_timetables.elections.scottish_parliament import (
     ScottishParliamentElection,
 )
@@ -19,13 +22,14 @@ from uk_election_timetables.elections.senedd_cymru import SeneddCymruElection
 from uk_election_timetables.elections.uk_parliament import UKParliamentElection
 
 __ALL__ = (
+    CityOfLondonLocalElection,
+    GreaterLondonAssemblyElection,
+    LocalElection,
+    MayoralElection,
+    NorthernIrelandAssemblyElection,
+    PoliceAndCrimeCommissionerElection,
+    Referendum,
     ScottishParliamentElection,
     SeneddCymruElection,
-    GreaterLondonAssemblyElection,
-    NorthernIrelandAssemblyElection,
-    LocalElection,
-    CityOfLondonLocalElection,
     UKParliamentElection,
-    PoliceAndCrimeCommissionerElection,
-    MayoralElection,
 )

--- a/uk_election_timetables/elections/referendum.py
+++ b/uk_election_timetables/elections/referendum.py
@@ -1,0 +1,9 @@
+from datetime import date
+
+from uk_election_timetables.election import Election
+
+
+class Referendum(Election):
+    @property
+    def sopn_publish_date(self) -> date:
+        raise NotImplementedError("No SOPN date for referenda")


### PR DESCRIPTION
In this PR, I am exposing a timetable for referendum election types. Previously `from_election_id("ref.2021-05-06")` threw a `NoSuchElectionTypeError`

As implemented, the calendar for referenda is:

|Event|Interval|
|----------------|----------------|
|Registration Deadline|12 working days before|
|VAC Application Deadline|6 working days before|
|SOPN Publish Date|N/A|
|Registration Deadline (E/W/S)|11 working days before|
|Registration Deadline (NI)|14 working days before|

AFAIK this is right, but in the case of a "big" referendum there might be custom rules.