### PR TITLE
adopt 'import datetime as dt' convention

### DIFF
--- a/tests/elections/test_city_of_london_local.py
+++ b/tests/elections/test_city_of_london_local.py
@@ -1,4 +1,4 @@
-from datetime import date
+import datetime as dt
 
 import pytest
 
@@ -11,20 +11,20 @@ from uk_election_timetables.elections.city_of_london_local import (
 
 registration_test_cases = [
     {
-        "poll_date": date(2025, 1, 1),
-        "expected_registration_deadline": date(2023, 11, 30),
+        "poll_date": dt.date(2025, 1, 1),
+        "expected_registration_deadline": dt.date(2023, 11, 30),
     },
     {
-        "poll_date": date(2025, 2, 15),
-        "expected_registration_deadline": date(2023, 11, 30),
+        "poll_date": dt.date(2025, 2, 15),
+        "expected_registration_deadline": dt.date(2023, 11, 30),
     },
     {
-        "poll_date": date(2025, 2, 16),
-        "expected_registration_deadline": date(2024, 11, 30),
+        "poll_date": dt.date(2025, 2, 16),
+        "expected_registration_deadline": dt.date(2024, 11, 30),
     },
     {
-        "poll_date": date(2025, 11, 29),
-        "expected_registration_deadline": date(2024, 11, 30),
+        "poll_date": dt.date(2025, 11, 29),
+        "expected_registration_deadline": dt.date(2024, 11, 30),
     },
 ]
 
@@ -40,19 +40,19 @@ def test_city_of_london_registration_deadline(election):
 sopn_test_cases = [
     {
         # https://candidates.democracyclub.org.uk/elections/local.city-of-london.cordwainer.by.2022-09-15/sopn/
-        "poll_date": date(2022, 9, 15),
-        "sopn_publish_date": date(2022, 8, 23),
+        "poll_date": dt.date(2022, 9, 15),
+        "sopn_publish_date": dt.date(2022, 8, 23),
     },
     {
         # https://candidates.democracyclub.org.uk/elections/local.city-of-london.bassishaw.by.2019-04-30/sopn/
         # includes an easter break
-        "poll_date": date(2019, 4, 30),
-        "sopn_publish_date": date(2019, 4, 2),
+        "poll_date": dt.date(2019, 4, 30),
+        "sopn_publish_date": dt.date(2019, 4, 2),
     },
     {
         # https://candidates.democracyclub.org.uk/elections/local.city-of-london-alder.cornhill.2022-05-26/sopn/
-        "poll_date": date(2022, 5, 26),
-        "sopn_publish_date": date(2022, 5, 4),
+        "poll_date": dt.date(2022, 5, 26),
+        "sopn_publish_date": dt.date(2022, 5, 4),
     },
 ]
 
@@ -108,10 +108,10 @@ def test_christmas_break_2014():
         2014, bank_holidays
     )
     assert _contains_matcher_for_date(
-        christmas_break_matchers, date(2014, 12, 24)
+        christmas_break_matchers, dt.date(2014, 12, 24)
     )
     assert _contains_matcher_for_date(
-        christmas_break_matchers, date(2014, 12, 29)
+        christmas_break_matchers, dt.date(2014, 12, 29)
     )
 
 
@@ -125,10 +125,10 @@ def test_christmas_break_2021():
         2021, bank_holidays
     )
     assert _contains_matcher_for_date(
-        christmas_break_matchers, date(2021, 12, 24)
+        christmas_break_matchers, dt.date(2021, 12, 24)
     )
     assert _contains_matcher_for_date(
-        christmas_break_matchers, date(2021, 12, 29)
+        christmas_break_matchers, dt.date(2021, 12, 29)
     )
 
 
@@ -142,10 +142,10 @@ def test_christmas_break_2022():
         2022, bank_holidays
     )
     assert _contains_matcher_for_date(
-        christmas_break_matchers, date(2022, 12, 23)
+        christmas_break_matchers, dt.date(2022, 12, 23)
     )
     assert _contains_matcher_for_date(
-        christmas_break_matchers, date(2022, 12, 28)
+        christmas_break_matchers, dt.date(2022, 12, 28)
     )
 
 
@@ -158,8 +158,8 @@ def test_christmas_break_2024():
         2024, bank_holidays
     )
     assert _contains_matcher_for_date(
-        christmas_break_matchers, date(2024, 12, 24)
+        christmas_break_matchers, dt.date(2024, 12, 24)
     )
     assert _contains_matcher_for_date(
-        christmas_break_matchers, date(2024, 12, 27)
+        christmas_break_matchers, dt.date(2024, 12, 27)
     )

--- a/tests/elections/test_greater_london_assembly.py
+++ b/tests/elections/test_greater_london_assembly.py
@@ -1,4 +1,4 @@
-from datetime import date
+import datetime as dt
 
 from uk_election_timetables.elections import GreaterLondonAssemblyElection
 
@@ -6,23 +6,23 @@ from uk_election_timetables.elections import GreaterLondonAssemblyElection
 # Reference election: gla.c.barnet-and-camden.2016-05-05
 def test_publish_date_greater_london_assembly():
     publish_date = GreaterLondonAssemblyElection(
-        date(2016, 5, 5)
+        dt.date(2016, 5, 5)
     ).sopn_publish_date
 
-    assert publish_date == date(2016, 4, 4)
+    assert publish_date == dt.date(2016, 4, 4)
 
 
 # Reference election: mayor.london.2016-05-05
 def test_publish_date_mayor_london():
     publish_date = GreaterLondonAssemblyElection(
-        date(2016, 5, 5)
+        dt.date(2016, 5, 5)
     ).sopn_publish_date
 
-    assert publish_date == date(2016, 4, 4)
+    assert publish_date == dt.date(2016, 4, 4)
 
 
 # Reference election: gla.2021-05-06
 def test_registration_deadline_london_assembly():
-    election = GreaterLondonAssemblyElection(date(2021, 5, 6))
+    election = GreaterLondonAssemblyElection(dt.date(2021, 5, 6))
 
-    assert election.registration_deadline == date(2021, 4, 19)
+    assert election.registration_deadline == dt.date(2021, 4, 19)

--- a/tests/elections/test_local.py
+++ b/tests/elections/test_local.py
@@ -1,4 +1,4 @@
-from datetime import date
+import datetime as dt
 
 from uk_election_timetables.calendars import Country
 from uk_election_timetables.elections import LocalElection
@@ -6,43 +6,43 @@ from uk_election_timetables.elections import LocalElection
 
 # Reference election: local.highland.wester-ross-strathpeffer-and-lochalsh.by.2018-12-06
 def test_publish_date_scottish_local():
-    election = LocalElection(date(2018, 12, 6), Country.SCOTLAND)
+    election = LocalElection(dt.date(2018, 12, 6), Country.SCOTLAND)
 
-    assert election.sopn_publish_date == date(2018, 11, 2)
+    assert election.sopn_publish_date == dt.date(2018, 11, 2)
 
 
 # Reference election: local.belfast.balmoral.2019-05-02
 def test_publish_date_northern_ireland_local():
-    election = LocalElection(date(2019, 5, 2), Country.NORTHERN_IRELAND)
+    election = LocalElection(dt.date(2019, 5, 2), Country.NORTHERN_IRELAND)
 
-    assert election.sopn_publish_date == date(2019, 4, 8)
+    assert election.sopn_publish_date == dt.date(2019, 4, 8)
 
 
 # Reference election: local.herefordshire.ross-north.2019-06-06
 def test_publish_date_local_election_england():
-    election = LocalElection(date(2019, 6, 6), country=Country.ENGLAND)
+    election = LocalElection(dt.date(2019, 6, 6), country=Country.ENGLAND)
 
-    assert election.sopn_publish_date == date(2019, 5, 9)
+    assert election.sopn_publish_date == dt.date(2019, 5, 9)
 
 
 # Reference election: local.2021-05-06
 def test_registration_deadline_local_election_england():
-    election = LocalElection(date(2021, 5, 6), country=Country.ENGLAND)
+    election = LocalElection(dt.date(2021, 5, 6), country=Country.ENGLAND)
 
-    assert election.registration_deadline == date(2021, 4, 19)
+    assert election.registration_deadline == dt.date(2021, 4, 19)
 
 
 # Reference election: local.2021-05-06
 def test_postal_vote_application_deadline_local_election_england():
-    election = LocalElection(date(2021, 5, 6), country=Country.ENGLAND)
+    election = LocalElection(dt.date(2021, 5, 6), country=Country.ENGLAND)
 
-    assert election.postal_vote_application_deadline == date(2021, 4, 20)
+    assert election.postal_vote_application_deadline == dt.date(2021, 4, 20)
 
 
 # Reference election: local.belfast.2023-05-18
 def test_postal_vote_application_deadline_local_election_northern_ireland():
     deadline = LocalElection(
-        date(2023, 5, 18), country=Country.NORTHERN_IRELAND
+        dt.date(2023, 5, 18), country=Country.NORTHERN_IRELAND
     ).postal_vote_application_deadline
 
-    assert deadline == date(2023, 4, 26)
+    assert deadline == dt.date(2023, 4, 26)

--- a/tests/elections/test_mayoral.py
+++ b/tests/elections/test_mayoral.py
@@ -1,24 +1,24 @@
-from datetime import date
+import datetime as dt
 
 from uk_election_timetables.elections import MayoralElection
 
 
 # Reference election: mayor.liverpool-city-ca.2017-05-04
 def test_publish_date_mayor():
-    election = MayoralElection(date(2017, 5, 4))
+    election = MayoralElection(dt.date(2017, 5, 4))
 
-    assert election.sopn_publish_date == date(2017, 4, 4)
+    assert election.sopn_publish_date == dt.date(2017, 4, 4)
 
 
 # Reference election: mayor.2021-05-06
 def test_registration_deadline_mayor():
-    election = MayoralElection(date(2021, 5, 6))
+    election = MayoralElection(dt.date(2021, 5, 6))
 
-    assert election.registration_deadline == date(2021, 4, 19)
+    assert election.registration_deadline == dt.date(2021, 4, 19)
 
 
 # Reference election: mayor.2021-05-06
 def test_postal_vote_application_deadline_mayor():
-    election = MayoralElection(date(2021, 5, 6))
+    election = MayoralElection(dt.date(2021, 5, 6))
 
-    assert election.postal_vote_application_deadline == date(2021, 4, 20)
+    assert election.postal_vote_application_deadline == dt.date(2021, 4, 20)

--- a/tests/elections/test_northern_ireland_assembly.py
+++ b/tests/elections/test_northern_ireland_assembly.py
@@ -1,4 +1,4 @@
-from datetime import date
+import datetime as dt
 
 from uk_election_timetables.elections import NorthernIrelandAssemblyElection
 
@@ -6,7 +6,7 @@ from uk_election_timetables.elections import NorthernIrelandAssemblyElection
 # Reference election: nia.belfast-east.2017-03-02
 def test_publish_date_northern_ireland_assembly():
     publish_date = NorthernIrelandAssemblyElection(
-        date(2017, 3, 2)
+        dt.date(2017, 3, 2)
     ).sopn_publish_date
 
-    assert publish_date == date(2017, 2, 8)
+    assert publish_date == dt.date(2017, 2, 8)

--- a/tests/elections/test_police_and_crime_commissioner.py
+++ b/tests/elections/test_police_and_crime_commissioner.py
@@ -1,24 +1,24 @@
-from datetime import date
+import datetime as dt
 
 from uk_election_timetables.elections import PoliceAndCrimeCommissionerElection
 
 
 # Reference election: pcc.avon-and-somerset.2016-05-05
 def test_publish_date_police_and_crime_commissioner():
-    election = PoliceAndCrimeCommissionerElection(date(2016, 5, 5))
+    election = PoliceAndCrimeCommissionerElection(dt.date(2016, 5, 5))
 
-    assert election.sopn_publish_date == date(2016, 4, 8)
+    assert election.sopn_publish_date == dt.date(2016, 4, 8)
 
 
 # Reference election: pcc.2021-05-06
 def test_registration_deadline_police_and_crime_commissioner():
-    election = PoliceAndCrimeCommissionerElection(date(2021, 5, 6))
+    election = PoliceAndCrimeCommissionerElection(dt.date(2021, 5, 6))
 
-    assert election.registration_deadline == date(2021, 4, 19)
+    assert election.registration_deadline == dt.date(2021, 4, 19)
 
 
 # Reference election: pcc.2021-05-06
 def test_postal_vote_application_deadline_police_and_crime_commissioner():
-    election = PoliceAndCrimeCommissionerElection(date(2021, 5, 6))
+    election = PoliceAndCrimeCommissionerElection(dt.date(2021, 5, 6))
 
-    assert election.postal_vote_application_deadline == date(2021, 4, 20)
+    assert election.postal_vote_application_deadline == dt.date(2021, 4, 20)

--- a/tests/elections/test_scottish_parliament.py
+++ b/tests/elections/test_scottish_parliament.py
@@ -1,4 +1,4 @@
-from datetime import date
+import datetime as dt
 
 import pytest
 
@@ -11,15 +11,15 @@ sopn_test_cases = [
         # Reference election: sp.c.shetland-islands.2021-05-06
         # https://candidates.democracyclub.org.uk/elections/sp.c.shetland-islands.2021-05-06/sopn/
         # In 2021 Easter Monday fell between SOPN Publish date and polling day
-        "poll_date": date(2021, 5, 6),
-        "sopn_publish_date": date(2021, 3, 31),
+        "poll_date": dt.date(2021, 5, 6),
+        "sopn_publish_date": dt.date(2021, 3, 31),
     },
     {
         # Reference election: sp.c.shetland-islands.2016-05-05
         # https://candidates.democracyclub.org.uk/elections/sp.c.shetland-islands.2016-05-05/sopn/
         # In 2016 Easter Monday was on 27th March so does not factor in here
-        "poll_date": date(2016, 5, 5),
-        "sopn_publish_date": date(2016, 4, 1),
+        "poll_date": dt.date(2016, 5, 5),
+        "sopn_publish_date": dt.date(2016, 4, 1),
     },
 ]
 
@@ -34,13 +34,13 @@ def test_publish_date_scottish_parliament(election):
 
 # Reference election: sp.2021-05-06
 def test_registration_deadline_scottish_parliament():
-    election = ScottishParliamentElection(date(2021, 5, 6))
+    election = ScottishParliamentElection(dt.date(2021, 5, 6))
 
-    assert election.registration_deadline == date(2021, 4, 19)
+    assert election.registration_deadline == dt.date(2021, 4, 19)
 
 
 # Reference election: sp.2021-05-06
 def test_postal_vote_application_deadline_scottish_parliament():
-    election = ScottishParliamentElection(date(2021, 5, 6))
+    election = ScottishParliamentElection(dt.date(2021, 5, 6))
 
-    assert election.postal_vote_application_deadline == date(2021, 4, 6)
+    assert election.postal_vote_application_deadline == dt.date(2021, 4, 6)

--- a/tests/elections/test_senedd_cymru.py
+++ b/tests/elections/test_senedd_cymru.py
@@ -1,24 +1,24 @@
-from datetime import date
+import datetime as dt
 
 from uk_election_timetables.elections import SeneddCymruElection
 
 
 # Reference election: naw.c.ceredigion.2016-05-05
 def test_publish_date_senedd_cymru():
-    publish_date = SeneddCymruElection(date(2016, 5, 5)).sopn_publish_date
+    publish_date = SeneddCymruElection(dt.date(2016, 5, 5)).sopn_publish_date
 
-    assert publish_date == date(2016, 4, 7)
+    assert publish_date == dt.date(2016, 4, 7)
 
 
 # Reference election: senedd.2021-05-06
 def test_registration_deadline_senedd_cymru():
-    election = SeneddCymruElection(date(2021, 5, 6))
+    election = SeneddCymruElection(dt.date(2021, 5, 6))
 
-    assert election.registration_deadline == date(2021, 4, 19)
+    assert election.registration_deadline == dt.date(2021, 4, 19)
 
 
 # Reference election: senedd.2021-05-06
 def test_postal_vote_application_deadline_senedd_cymru():
-    election = SeneddCymruElection(date(2021, 5, 6))
+    election = SeneddCymruElection(dt.date(2021, 5, 6))
 
-    assert election.postal_vote_application_deadline == date(2021, 4, 20)
+    assert election.postal_vote_application_deadline == dt.date(2021, 4, 20)

--- a/tests/elections/test_uk_parliament.py
+++ b/tests/elections/test_uk_parliament.py
@@ -1,4 +1,4 @@
-from datetime import date
+import datetime as dt
 
 import pytest
 
@@ -8,57 +8,59 @@ from uk_election_timetables.elections import UKParliamentElection
 
 # Reference election: parl.aberavon.2017-06-08
 def test_publish_date_uk_parliament_wales():
-    election = UKParliamentElection(date(2017, 6, 8), Country.WALES)
+    election = UKParliamentElection(dt.date(2017, 6, 8), Country.WALES)
 
-    assert election.sopn_publish_date == date(2017, 5, 11)
+    assert election.sopn_publish_date == dt.date(2017, 5, 11)
 
 
 # Reference election: parl.na-h-eileanan-an-iar.2017-06-08
 def test_publish_date_uk_parliament_scotland():
-    election = UKParliamentElection(date(2017, 6, 8), Country.SCOTLAND)
+    election = UKParliamentElection(dt.date(2017, 6, 8), Country.SCOTLAND)
 
-    assert election.sopn_publish_date == date(2017, 5, 11)
+    assert election.sopn_publish_date == dt.date(2017, 5, 11)
 
 
 # Reference election: parl.belfast-east.2017-06-08
 def test_publish_date_uk_parliament_northern_ireland():
-    election = UKParliamentElection(date(2017, 6, 8), Country.NORTHERN_IRELAND)
+    election = UKParliamentElection(
+        dt.date(2017, 6, 8), Country.NORTHERN_IRELAND
+    )
 
-    assert election.sopn_publish_date == date(2017, 5, 11)
+    assert election.sopn_publish_date == dt.date(2017, 5, 11)
 
 
 # Reference election: parl.hemel-hempstead.2017-06-08
 def test_publish_date_uk_parliament_england():
-    election = UKParliamentElection(date(2017, 6, 8), Country.ENGLAND)
+    election = UKParliamentElection(dt.date(2017, 6, 8), Country.ENGLAND)
 
-    assert election.sopn_publish_date == date(2017, 5, 11)
+    assert election.sopn_publish_date == dt.date(2017, 5, 11)
 
 
 # Reference election: parl.2019-12-12
 def test_publish_date_uk_parliament_2019():
-    election = UKParliamentElection(date(2019, 12, 12))
+    election = UKParliamentElection(dt.date(2019, 12, 12))
 
-    assert election.sopn_publish_date == date(2019, 11, 14)
+    assert election.sopn_publish_date == dt.date(2019, 11, 14)
 
 
 # Reference election: parl.2019-12-12
 def test_postal_vote_application_deadline_uk_parliament_2019():
-    election = UKParliamentElection(date(2019, 12, 12))
+    election = UKParliamentElection(dt.date(2019, 12, 12))
 
-    assert election.postal_vote_application_deadline == date(2019, 11, 26)
+    assert election.postal_vote_application_deadline == dt.date(2019, 11, 26)
 
 
 @pytest.mark.parametrize(
     "country, deadline_date",
     [
-        (Country.ENGLAND, date(2023, 4, 3)),
+        (Country.ENGLAND, dt.date(2023, 4, 3)),
         # No Easter Monday BH in Scotland
         # and Easter Monday is non special-cased for Scotland in
         # The Voter Identification Regulations 2022
-        (Country.SCOTLAND, date(2023, 4, 4)),
-        (Country.WALES, date(2023, 4, 3)),
+        (Country.SCOTLAND, dt.date(2023, 4, 4)),
+        (Country.WALES, dt.date(2023, 4, 3)),
     ],
 )
 def test_vac_application_deadline_uk_parliament(country, deadline_date):
-    election = UKParliamentElection(date(2023, 4, 13), country=country)
+    election = UKParliamentElection(dt.date(2023, 4, 13), country=country)
     assert election.vac_application_deadline == deadline_date

--- a/tests/test_date.py
+++ b/tests/test_date.py
@@ -1,4 +1,4 @@
-from datetime import date
+import datetime as dt
 
 import pytest
 
@@ -6,103 +6,103 @@ from uk_election_timetables.date import DateMatcher, days_before, easter_sunday
 
 
 def test_zero_days_before():
-    example = date(2020, 1, 1)
+    example = dt.date(2020, 1, 1)
 
     assert days_before(example, 0) == example
 
 
 def test_non_zero_days_before():
-    example = date(2020, 1, 1)
+    example = dt.date(2020, 1, 1)
 
-    assert days_before(example, 1) == date(2019, 12, 31)
-    assert days_before(example, 2) == date(2019, 12, 30)
+    assert days_before(example, 1) == dt.date(2019, 12, 31)
+    assert days_before(example, 2) == dt.date(2019, 12, 30)
 
 
 def test_ignore_weekends():
-    example = date(2020, 1, 6)  # Monday
+    example = dt.date(2020, 1, 6)  # Monday
 
-    assert days_before(example, 1) == date(2020, 1, 3)
+    assert days_before(example, 1) == dt.date(2020, 1, 3)
 
 
 def test_ignore_exempted_day_with_year():
-    example = date(2020, 1, 1)
+    example = dt.date(2020, 1, 1)
 
     exempted_dates = [DateMatcher(year=2019, month=12, day=31)]
 
-    assert days_before(example, 1, exempted_dates) == date(2019, 12, 30)
+    assert days_before(example, 1, exempted_dates) == dt.date(2019, 12, 30)
 
 
 def test_ignore_exempted_day_without_year():
-    example = date(2020, 1, 1)
+    example = dt.date(2020, 1, 1)
 
     exempted_dates = [DateMatcher(month=12, day=31)]
 
-    assert days_before(example, 1, exempted_dates) == date(2019, 12, 30)
+    assert days_before(example, 1, exempted_dates) == dt.date(2019, 12, 30)
 
 
 # vendored from dateutil
 easter_dates = [
-    date(1990, 4, 15),
-    date(1991, 3, 31),
-    date(1992, 4, 19),
-    date(1993, 4, 11),
-    date(1994, 4, 3),
-    date(1995, 4, 16),
-    date(1996, 4, 7),
-    date(1997, 3, 30),
-    date(1998, 4, 12),
-    date(1999, 4, 4),
-    date(2000, 4, 23),
-    date(2001, 4, 15),
-    date(2002, 3, 31),
-    date(2003, 4, 20),
-    date(2004, 4, 11),
-    date(2005, 3, 27),
-    date(2006, 4, 16),
-    date(2007, 4, 8),
-    date(2008, 3, 23),
-    date(2009, 4, 12),
-    date(2010, 4, 4),
-    date(2011, 4, 24),
-    date(2012, 4, 8),
-    date(2013, 3, 31),
-    date(2014, 4, 20),
-    date(2015, 4, 5),
-    date(2016, 3, 27),
-    date(2017, 4, 16),
-    date(2018, 4, 1),
-    date(2019, 4, 21),
-    date(2020, 4, 12),
-    date(2021, 4, 4),
-    date(2022, 4, 17),
-    date(2023, 4, 9),
-    date(2024, 3, 31),
-    date(2025, 4, 20),
-    date(2026, 4, 5),
-    date(2027, 3, 28),
-    date(2028, 4, 16),
-    date(2029, 4, 1),
-    date(2030, 4, 21),
-    date(2031, 4, 13),
-    date(2032, 3, 28),
-    date(2033, 4, 17),
-    date(2034, 4, 9),
-    date(2035, 3, 25),
-    date(2036, 4, 13),
-    date(2037, 4, 5),
-    date(2038, 4, 25),
-    date(2039, 4, 10),
-    date(2040, 4, 1),
-    date(2041, 4, 21),
-    date(2042, 4, 6),
-    date(2043, 3, 29),
-    date(2044, 4, 17),
-    date(2045, 4, 9),
-    date(2046, 3, 25),
-    date(2047, 4, 14),
-    date(2048, 4, 5),
-    date(2049, 4, 18),
-    date(2050, 4, 10),
+    dt.date(1990, 4, 15),
+    dt.date(1991, 3, 31),
+    dt.date(1992, 4, 19),
+    dt.date(1993, 4, 11),
+    dt.date(1994, 4, 3),
+    dt.date(1995, 4, 16),
+    dt.date(1996, 4, 7),
+    dt.date(1997, 3, 30),
+    dt.date(1998, 4, 12),
+    dt.date(1999, 4, 4),
+    dt.date(2000, 4, 23),
+    dt.date(2001, 4, 15),
+    dt.date(2002, 3, 31),
+    dt.date(2003, 4, 20),
+    dt.date(2004, 4, 11),
+    dt.date(2005, 3, 27),
+    dt.date(2006, 4, 16),
+    dt.date(2007, 4, 8),
+    dt.date(2008, 3, 23),
+    dt.date(2009, 4, 12),
+    dt.date(2010, 4, 4),
+    dt.date(2011, 4, 24),
+    dt.date(2012, 4, 8),
+    dt.date(2013, 3, 31),
+    dt.date(2014, 4, 20),
+    dt.date(2015, 4, 5),
+    dt.date(2016, 3, 27),
+    dt.date(2017, 4, 16),
+    dt.date(2018, 4, 1),
+    dt.date(2019, 4, 21),
+    dt.date(2020, 4, 12),
+    dt.date(2021, 4, 4),
+    dt.date(2022, 4, 17),
+    dt.date(2023, 4, 9),
+    dt.date(2024, 3, 31),
+    dt.date(2025, 4, 20),
+    dt.date(2026, 4, 5),
+    dt.date(2027, 3, 28),
+    dt.date(2028, 4, 16),
+    dt.date(2029, 4, 1),
+    dt.date(2030, 4, 21),
+    dt.date(2031, 4, 13),
+    dt.date(2032, 3, 28),
+    dt.date(2033, 4, 17),
+    dt.date(2034, 4, 9),
+    dt.date(2035, 3, 25),
+    dt.date(2036, 4, 13),
+    dt.date(2037, 4, 5),
+    dt.date(2038, 4, 25),
+    dt.date(2039, 4, 10),
+    dt.date(2040, 4, 1),
+    dt.date(2041, 4, 21),
+    dt.date(2042, 4, 6),
+    dt.date(2043, 3, 29),
+    dt.date(2044, 4, 17),
+    dt.date(2045, 4, 9),
+    dt.date(2046, 3, 25),
+    dt.date(2047, 4, 14),
+    dt.date(2048, 4, 5),
+    dt.date(2049, 4, 18),
+    dt.date(2050, 4, 10),
 ]
 
 

--- a/tests/test_election.py
+++ b/tests/test_election.py
@@ -1,4 +1,4 @@
-import datetime
+import datetime as dt
 from typing import Dict
 
 import pytest
@@ -14,7 +14,7 @@ def test_timetable_sopn_publish_date():
 
     sopn_publish_date = lookup(election, "List of candidates published")
 
-    assert sopn_publish_date["date"] == datetime.date(2019, 1, 25)
+    assert sopn_publish_date["date"] == dt.date(2019, 1, 25)
 
 
 def test_timetable_registration_deadline():
@@ -24,7 +24,7 @@ def test_timetable_registration_deadline():
         election, "Register to vote deadline"
     )
 
-    assert electoral_registration_deadline["date"] == datetime.date(2021, 4, 19)
+    assert electoral_registration_deadline["date"] == dt.date(2021, 4, 19)
 
 
 def test_timetable_postal_vote_application_deadline():
@@ -32,7 +32,7 @@ def test_timetable_postal_vote_application_deadline():
 
     postal_vote_dealine = lookup(election, "Postal vote application deadline")
 
-    assert postal_vote_dealine["date"] == datetime.date(2021, 4, 20)
+    assert postal_vote_dealine["date"] == dt.date(2021, 4, 20)
 
 
 def test_timetable_vac_application_deadline():
@@ -40,7 +40,7 @@ def test_timetable_vac_application_deadline():
 
     vac_deadline = lookup(election, "VAC application deadline")
 
-    assert vac_deadline["date"] == datetime.date(2023, 4, 25)
+    assert vac_deadline["date"] == dt.date(2023, 4, 25)
 
 
 def test_timetable_sort_order():
@@ -51,22 +51,22 @@ def test_timetable_sort_order():
     assert election.timetable == [
         {
             "label": "List of candidates published",
-            "date": datetime.date(2021, 4, 8),
+            "date": dt.date(2021, 4, 8),
             "event": "SOPN_PUBLISH_DATE",
         },
         {
             "label": "Register to vote deadline",
-            "date": datetime.date(2021, 4, 19),
+            "date": dt.date(2021, 4, 19),
             "event": "REGISTRATION_DEADLINE",
         },
         {
             "label": "Postal vote application deadline",
-            "date": datetime.date(2021, 4, 20),
+            "date": dt.date(2021, 4, 20),
             "event": "POSTAL_VOTE_APPLICATION_DEADLINE",
         },
         {
             "label": "VAC application deadline",
-            "date": datetime.date(2021, 4, 27),
+            "date": dt.date(2021, 4, 27),
             "event": "VAC_APPLICATION_DEADLINE",
         },
     ]
@@ -80,22 +80,22 @@ def test_timetable_sort_order_scottish_parliament_postal_vote():
     assert election.timetable == [
         {
             "label": "List of candidates published",
-            "date": datetime.date(2021, 3, 31),
+            "date": dt.date(2021, 3, 31),
             "event": "SOPN_PUBLISH_DATE",
         },
         {
             "label": "Postal vote application deadline",
-            "date": datetime.date(2021, 4, 6),
+            "date": dt.date(2021, 4, 6),
             "event": "POSTAL_VOTE_APPLICATION_DEADLINE",
         },
         {
             "label": "Register to vote deadline",
-            "date": datetime.date(2021, 4, 19),
+            "date": dt.date(2021, 4, 19),
             "event": "REGISTRATION_DEADLINE",
         },
         {
             "label": "VAC application deadline",
-            "date": datetime.date(2021, 4, 27),
+            "date": dt.date(2021, 4, 27),
             "event": "VAC_APPLICATION_DEADLINE",
         },
     ]
@@ -109,17 +109,17 @@ def test_timetable_referendum():
     assert election.timetable == [
         {
             "label": "Register to vote deadline",
-            "date": datetime.date(2021, 4, 19),
+            "date": dt.date(2021, 4, 19),
             "event": "REGISTRATION_DEADLINE",
         },
         {
             "label": "Postal vote application deadline",
-            "date": datetime.date(2021, 4, 20),
+            "date": dt.date(2021, 4, 20),
             "event": "POSTAL_VOTE_APPLICATION_DEADLINE",
         },
         {
             "label": "VAC application deadline",
-            "date": datetime.date(2021, 4, 27),
+            "date": dt.date(2021, 4, 27),
             "event": "VAC_APPLICATION_DEADLINE",
         },
     ]
@@ -135,16 +135,16 @@ def test_get_date_for_event_type():
     election = from_election_id("parl.2019-02-21", country=Country.ENGLAND)
     assert election.get_date_for_event_type(
         TimetableEvent("List of candidates published")
-    ) == datetime.date(2019, 1, 25)
+    ) == dt.date(2019, 1, 25)
     assert election.get_date_for_event_type(
         TimetableEvent("Postal vote application deadline")
-    ) == datetime.date(2019, 2, 6)
+    ) == dt.date(2019, 2, 6)
     assert election.get_date_for_event_type(
         TimetableEvent("Register to vote deadline")
-    ) == datetime.date(2019, 2, 5)
+    ) == dt.date(2019, 2, 5)
     assert election.get_date_for_event_type(
         TimetableEvent("VAC application deadline")
-    ) == datetime.date(2019, 2, 13)
+    ) == dt.date(2019, 2, 13)
 
 
 def test_event_type_enum():
@@ -281,14 +281,14 @@ def test_from_election_types_types(election):
 def test_city_of_london_does_not_mutate_global_calendar():
     assert from_election_id(
         "mayor.doncaster.2025-05-01", Country.ENGLAND
-    ).sopn_publish_date == datetime.date(2025, 4, 2)
+    ).sopn_publish_date == dt.date(2025, 4, 2)
 
     assert from_election_id(
         "local.city-of-london.aldersgate.2025-03-20", Country.ENGLAND
-    ).sopn_publish_date == datetime.date(2025, 2, 26)
+    ).sopn_publish_date == dt.date(2025, 2, 26)
 
     # calculating the date for a City of London election
     # shouldn't change this result
     assert from_election_id(
         "mayor.doncaster.2025-05-01", Country.ENGLAND
-    ).sopn_publish_date == datetime.date(2025, 4, 2)
+    ).sopn_publish_date == dt.date(2025, 4, 2)

--- a/tests/test_historic_sopn_publish_dates.py
+++ b/tests/test_historic_sopn_publish_dates.py
@@ -1,5 +1,5 @@
+import datetime as dt
 from csv import DictReader
-from datetime import datetime
 
 from pytest import mark
 
@@ -21,7 +21,7 @@ with open("./tests/historic_sopn_data.csv") as f:
 
 
 def read_date(date_as_string):
-    return datetime.strptime(date_as_string, "%Y-%m-%d").date()
+    return dt.datetime.strptime(date_as_string, "%Y-%m-%d").date()
 
 
 def same_or_next_day(actual_date, expected_date):

--- a/tests/test_sopn_publish_date.py
+++ b/tests/test_sopn_publish_date.py
@@ -1,4 +1,4 @@
-from datetime import date
+import datetime as dt
 
 from pytest import raises
 
@@ -31,19 +31,19 @@ def test_publish_date_local_id():
 def test_publish_date_local_id_with_country():
     election = from_election_id("local.2019-02-21", country=Country.ENGLAND)
 
-    assert election.sopn_publish_date == date(2019, 1, 25)
+    assert election.sopn_publish_date == dt.date(2019, 1, 25)
 
 
 def test_publish_date_parl_id_with_country():
     election = from_election_id("parl.2019-02-21", country=Country.ENGLAND)
 
-    assert election.sopn_publish_date == date(2019, 1, 25)
+    assert election.sopn_publish_date == dt.date(2019, 1, 25)
 
 
 def test_publish_date_parl_id_without_country():
     election = from_election_id("parl.2019-02-21")
 
-    assert election.sopn_publish_date == date(2019, 1, 25)
+    assert election.sopn_publish_date == dt.date(2019, 1, 25)
 
 
 def test_publish_date_not_an_election_type():
@@ -56,7 +56,7 @@ def test_publish_date_not_an_election_type():
 def test_publish_date_id_that_does_not_need_country():
     election = from_election_id("naw.c.ceredigion.2016-05-05")
 
-    assert election.sopn_publish_date == date(2016, 4, 7)
+    assert election.sopn_publish_date == dt.date(2016, 4, 7)
 
 
 def test_publish_date_invalid_id():
@@ -82,7 +82,7 @@ def test_publish_date_invalid_date():
 def test_publish_date_senedd_election_id():
     election = from_election_id("senedd.c.ceredigion.2016-05-05")
 
-    assert election.sopn_publish_date == date(2016, 4, 7)
+    assert election.sopn_publish_date == dt.date(2016, 4, 7)
 
 
 def test_publish_date_referendum():
@@ -95,12 +95,14 @@ def test_publish_date_referendum():
 
 def test_christmas_eve_not_counted():
     election_and_expected_sopn_date = {
-        PoliceAndCrimeCommissionerElection: date(2018, 12, 11),
-        UKParliamentElection: date(2018, 12, 7),
-        ScottishParliamentElection: date(2018, 12, 3),
-        NorthernIrelandAssemblyElection: date(2018, 12, 13),
-        SeneddCymruElection: date(2018, 12, 10),
+        PoliceAndCrimeCommissionerElection: dt.date(2018, 12, 11),
+        UKParliamentElection: dt.date(2018, 12, 7),
+        ScottishParliamentElection: dt.date(2018, 12, 3),
+        NorthernIrelandAssemblyElection: dt.date(2018, 12, 13),
+        SeneddCymruElection: dt.date(2018, 12, 10),
     }
 
     for election_on, expected_date in election_and_expected_sopn_date.items():
-        assert election_on(date(2019, 1, 10)).sopn_publish_date == expected_date
+        assert (
+            election_on(dt.date(2019, 1, 10)).sopn_publish_date == expected_date
+        )

--- a/uk_election_timetables/bank_holidays.py
+++ b/uk_election_timetables/bank_holidays.py
@@ -1,6 +1,6 @@
+import datetime as dt
 import json
 import os
-from datetime import datetime
 from typing import Dict, List
 
 import requests
@@ -46,11 +46,11 @@ def combine_bank_holiday_lists(
         combined_events = sorted(combined_events, key=lambda d: d["date"])
 
         # Remove duplicated records (any events within date range of .gov list which are not present in .gov list)
-        earliest_new_event: datetime.date = datetime.strptime(
+        earliest_new_event: dt.date = dt.datetime.strptime(
             new_events[0]["date"], "%Y-%m-%d"
         ).date()
         for event in combined_events:
-            event_date: datetime.date = datetime.strptime(
+            event_date: dt.date = dt.datetime.strptime(
                 event["date"], "%Y-%m-%d"
             ).date()
             if (event_date >= earliest_new_event) and (event not in new_events):

--- a/uk_election_timetables/calendars.py
+++ b/uk_election_timetables/calendars.py
@@ -1,7 +1,7 @@
+import datetime as dt
 import json
 import os
 from abc import ABC, abstractmethod
-from datetime import date, datetime, timedelta
 from enum import Enum
 from typing import List
 
@@ -51,7 +51,7 @@ class BankHolidayCalendar(BaseCalendar):
 
     @staticmethod
     def create_matcher_from_entry(entry: dict) -> DateMatcher:
-        event_date = datetime.strptime(entry["date"], "%Y-%m-%d")
+        event_date = dt.datetime.strptime(entry["date"], "%Y-%m-%d")
 
         return DateMatcher(
             name=entry["title"],
@@ -175,7 +175,7 @@ class EasterMondayRule(ExcludedDateRule):
         This rule allows us to easily extend the Scotland holiday
         calendar when necessary.
         """
-        easter_monday = easter_sunday(year) + timedelta(days=1)
+        easter_monday = easter_sunday(year) + dt.timedelta(days=1)
         return [
             DateMatcher(
                 name="Easter Monday",
@@ -187,8 +187,8 @@ class EasterMondayRule(ExcludedDateRule):
 
 
 def working_days_before(
-    end_date: date, days: int, calendar: BaseCalendar
-) -> date:
+    end_date: dt.date, days: int, calendar: BaseCalendar
+) -> dt.date:
     """
     Return date corresponding to `count` working days before `poll_date` according to the given bank holiday calendar
 

--- a/uk_election_timetables/date.py
+++ b/uk_election_timetables/date.py
@@ -1,4 +1,4 @@
-from datetime import date, timedelta
+import datetime as dt
 from typing import List
 
 SATURDAY = 5
@@ -20,7 +20,7 @@ class DateMatcher:
         self.day = day
         self.year = year
 
-    def matches(self, other: date) -> bool:
+    def matches(self, other: dt.date) -> bool:
         """
         Return whether the input date matches the attributes of this class
 
@@ -40,8 +40,8 @@ class DateMatcher:
 
 
 def days_before(
-    poll_date: date, days: int, ignore: List[DateMatcher] = None
-) -> date:
+    poll_date: dt.date, days: int, ignore: List[DateMatcher] = None
+) -> dt.date:
     """
     Return date corresponding to `days` working days before `poll_date`, not counting the list of provided exemptions
 
@@ -52,7 +52,7 @@ def days_before(
     """
 
     while days > 0:
-        poll_date -= timedelta(days=1)
+        poll_date -= dt.timedelta(days=1)
 
         if poll_date.weekday() in WEEKEND:
             continue
@@ -65,7 +65,7 @@ def days_before(
     return poll_date
 
 
-def easter_sunday(year: int) -> date:
+def easter_sunday(year: int) -> dt.date:
     # Compute Easter Sunday for a given year using Revised Gregorian algorithm
     # vendored from dateutil
     y = year
@@ -78,4 +78,4 @@ def easter_sunday(year: int) -> date:
     p = i - j + e
     d = 1 + (p + 27 + (p + 6) // 40) % 31
     m = 3 + (p + 26) // 30
-    return date(int(y), int(m), int(d))
+    return dt.date(int(y), int(m), int(d))

--- a/uk_election_timetables/election.py
+++ b/uk_election_timetables/election.py
@@ -1,6 +1,6 @@
 import contextlib
+import datetime as dt
 from abc import ABCMeta, abstractmethod
-from datetime import date, datetime, timezone
 from enum import Enum
 from typing import Dict, List
 
@@ -22,12 +22,12 @@ class TimetableEvent(Enum):
 class Election(metaclass=ABCMeta):
     BANK_HOLIDAY_CALENDAR = UnitedKingdomBankHolidays()
 
-    def __init__(self, poll_date: date, country: Country):
+    def __init__(self, poll_date: dt.date, country: Country):
         self.poll_date = poll_date
         self.country = country
 
     @property
-    def postal_vote_application_deadline(self) -> date:
+    def postal_vote_application_deadline(self) -> dt.date:
         """
         Calculates the postal vote application deadline for this Election
 
@@ -43,7 +43,7 @@ class Election(metaclass=ABCMeta):
         return working_days_before(self.poll_date, 11, self._calendar())
 
     @property
-    def vac_application_deadline(self) -> date:
+    def vac_application_deadline(self) -> dt.date:
         """
         Calculates the Voter Authority Certificate (VAC) application deadline for this Election
 
@@ -55,11 +55,11 @@ class Election(metaclass=ABCMeta):
 
     @property
     @abstractmethod
-    def sopn_publish_date(self) -> date:
+    def sopn_publish_date(self) -> dt.date:
         pass
 
     @property
-    def registration_deadline(self) -> date:
+    def registration_deadline(self) -> dt.date:
         """
         Calculates the voter registration deadline for this Election
 
@@ -131,10 +131,10 @@ class Election(metaclass=ABCMeta):
 
     def is_before(self, event, date=None):
         if not date:
-            date = datetime.now(timezone.utc).date()
+            date = dt.datetime.now(dt.timezone.utc).date()
         return self.get_date_for_event_type(event) >= date
 
     def is_after(self, event, date=None):
         if not date:
-            date = datetime.now(timezone.utc).date()
+            date = dt.datetime.now(dt.timezone.utc).date()
         return self.get_date_for_event_type(event) < date

--- a/uk_election_timetables/election_ids.py
+++ b/uk_election_timetables/election_ids.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime
+import datetime as dt
 
 from uk_election_timetables.calendars import Country
 from uk_election_timetables.election import Election
@@ -52,7 +52,7 @@ class AmbiguousElectionIdError(Exception):
         return "Cannot derive country from election id [%s]" % self.election_id
 
 
-def type_and_poll_date(election_id: str) -> (str, date):
+def type_and_poll_date(election_id: str) -> (str, dt.date):
     """
     Extract election_type (e.g. parl, local, mayor) and poll_date from an election id.
 
@@ -62,7 +62,7 @@ def type_and_poll_date(election_id: str) -> (str, date):
     try:
         election_type, *_, poll_date = election_id.split(".")
 
-        date_of_poll = datetime.strptime(poll_date, "%Y-%m-%d").date()
+        date_of_poll = dt.datetime.strptime(poll_date, "%Y-%m-%d").date()
 
         return election_type, date_of_poll
     except Exception:

--- a/uk_election_timetables/elections/city_of_london_local.py
+++ b/uk_election_timetables/elections/city_of_london_local.py
@@ -1,4 +1,4 @@
-from datetime import date, timedelta
+import datetime as dt
 from typing import List
 
 from uk_election_timetables.calendars import (
@@ -10,7 +10,7 @@ from uk_election_timetables.date import WEEKEND, DateMatcher, easter_sunday
 from uk_election_timetables.election import Election
 
 
-def _is_bank_holiday(date: date, bank_holidays: List[DateMatcher]) -> bool:
+def _is_bank_holiday(date: dt.date, bank_holidays: List[DateMatcher]) -> bool:
     return any(bh.matches(date) for bh in bank_holidays)
 
 
@@ -23,9 +23,9 @@ class EasterBreakRule(ExcludedDateRule):
         and ending with the Tuesday after Easter Day
         """
         easter_break = []
-        maundy_thursday = easter_sunday(year) - timedelta(days=3)
+        maundy_thursday = easter_sunday(year) - dt.timedelta(days=3)
         for offset in range(0, 6):
-            day = maundy_thursday + timedelta(days=offset)
+            day = maundy_thursday + dt.timedelta(days=offset)
             easter_break.append(
                 DateMatcher(
                     name="City of London Easter Break",
@@ -48,15 +48,15 @@ class ChristmasBreakRule(ExcludedDateRule):
         """
         christmas_break = []
 
-        break_start = date(year, 12, 24)
+        break_start = dt.date(year, 12, 24)
         while break_start.weekday() in WEEKEND:
-            break_start -= timedelta(days=1)
+            break_start -= dt.timedelta(days=1)
 
-        break_end = date(year, 12, 27)
+        break_end = dt.date(year, 12, 27)
         while break_end.weekday() in WEEKEND or _is_bank_holiday(
             break_end, bank_holidays
         ):
-            break_end += timedelta(days=1)
+            break_end += dt.timedelta(days=1)
 
         current_date = break_start
         while current_date <= break_end:
@@ -68,19 +68,19 @@ class ChristmasBreakRule(ExcludedDateRule):
                     day=current_date.day,
                 )
             )
-            current_date += timedelta(days=1)
+            current_date += dt.timedelta(days=1)
         return christmas_break
 
 
 class CityOfLondonLocalElection(Election):
-    def __init__(self, poll_date: date):
+    def __init__(self, poll_date: dt.date):
         """
         :param poll_date: a datetime representing the date of the poll
         """
         Election.__init__(self, poll_date, Country.ENGLAND)
 
     @property
-    def sopn_publish_date(self) -> date:
+    def sopn_publish_date(self) -> dt.date:
         """
         Calculate the "SOPN publish date" for a City of London local election.
 
@@ -111,12 +111,12 @@ class CityOfLondonLocalElection(Election):
         return working_days_before(self.poll_date, 16, calendar)
 
     @property
-    def registration_deadline(self) -> date:
+    def registration_deadline(self) -> dt.date:
         """
         Calculates the voter registration deadline for a City of London local election.
 
         :return: a datetime representing the voter registration deadline
         """
-        if self.poll_date <= date(self.poll_date.year, 2, 15):
-            return date(self.poll_date.year - 2, 11, 30)
-        return date(self.poll_date.year - 1, 11, 30)
+        if self.poll_date <= dt.date(self.poll_date.year, 2, 15):
+            return dt.date(self.poll_date.year - 2, 11, 30)
+        return dt.date(self.poll_date.year - 1, 11, 30)

--- a/uk_election_timetables/elections/greater_london_assembly.py
+++ b/uk_election_timetables/elections/greater_london_assembly.py
@@ -1,18 +1,18 @@
-from datetime import date
+import datetime as dt
 
 from uk_election_timetables.calendars import Country, working_days_before
 from uk_election_timetables.election import Election
 
 
 class GreaterLondonAssemblyElection(Election):
-    def __init__(self, poll_date: date):
+    def __init__(self, poll_date: dt.date):
         """
         :param poll_date: a datetime representing the date of the poll
         """
         Election.__init__(self, poll_date, Country.ENGLAND)
 
     @property
-    def sopn_publish_date(self) -> date:
+    def sopn_publish_date(self) -> dt.date:
         """
         Calculate the publish date for an election to the Greater London Assembly
 

--- a/uk_election_timetables/elections/local.py
+++ b/uk_election_timetables/elections/local.py
@@ -1,4 +1,4 @@
-from datetime import date
+import datetime as dt
 
 from uk_election_timetables.calendars import (
     Country,
@@ -10,7 +10,7 @@ from uk_election_timetables.election import Election
 
 class LocalElection(Election):
     @property
-    def sopn_publish_date(self) -> date:
+    def sopn_publish_date(self) -> dt.date:
         """
         Calculate the publish date for a local election.
 

--- a/uk_election_timetables/elections/mayor.py
+++ b/uk_election_timetables/elections/mayor.py
@@ -1,18 +1,18 @@
-from datetime import date
+import datetime as dt
 
 from uk_election_timetables.calendars import Country, working_days_before
 from uk_election_timetables.election import Election
 
 
 class MayoralElection(Election):
-    def __init__(self, poll_date: date):
+    def __init__(self, poll_date: dt.date):
         """
         :param poll_date: a datetime representing the date of the poll
         """
         Election.__init__(self, poll_date, Country.ENGLAND)
 
     @property
-    def sopn_publish_date(self) -> date:
+    def sopn_publish_date(self) -> dt.date:
         """
         Calculate the publish date for an election to the position of Mayor in England and Wales
 

--- a/uk_election_timetables/elections/northern_ireland_assembly.py
+++ b/uk_election_timetables/elections/northern_ireland_assembly.py
@@ -1,18 +1,18 @@
-from datetime import date
+import datetime as dt
 
 from uk_election_timetables.calendars import Country, working_days_before
 from uk_election_timetables.election import Election
 
 
 class NorthernIrelandAssemblyElection(Election):
-    def __init__(self, poll_date: date):
+    def __init__(self, poll_date: dt.date):
         """
         :param poll_date: a datetime representing the date of the poll
         """
         Election.__init__(self, poll_date, Country.NORTHERN_IRELAND)
 
     @property
-    def sopn_publish_date(self) -> date:
+    def sopn_publish_date(self) -> dt.date:
         """
         Calculate the publish date for an election to the Northern Ireland Assembly
 

--- a/uk_election_timetables/elections/police_and_crime_commissioner.py
+++ b/uk_election_timetables/elections/police_and_crime_commissioner.py
@@ -1,18 +1,18 @@
-from datetime import date
+import datetime as dt
 
 from uk_election_timetables.calendars import Country, working_days_before
 from uk_election_timetables.election import Election
 
 
 class PoliceAndCrimeCommissionerElection(Election):
-    def __init__(self, poll_date: date):
+    def __init__(self, poll_date: dt.date):
         """
         :param poll_date: a datetime representing the date of the poll
         """
         Election.__init__(self, poll_date, Country.ENGLAND)
 
     @property
-    def sopn_publish_date(self) -> date:
+    def sopn_publish_date(self) -> dt.date:
         """
         Calculate the publish date for an election to the position of Police and Crime Commissioner
 

--- a/uk_election_timetables/elections/referendum.py
+++ b/uk_election_timetables/elections/referendum.py
@@ -1,9 +1,9 @@
-from datetime import date
+import datetime as dt
 
 from uk_election_timetables.election import Election
 
 
 class Referendum(Election):
     @property
-    def sopn_publish_date(self) -> date:
+    def sopn_publish_date(self) -> dt.date:
         raise NotImplementedError("No SOPN date for referenda")

--- a/uk_election_timetables/elections/scottish_parliament.py
+++ b/uk_election_timetables/elections/scottish_parliament.py
@@ -1,4 +1,4 @@
-from datetime import date
+import datetime as dt
 
 from uk_election_timetables.calendars import (
     Country,
@@ -9,14 +9,14 @@ from uk_election_timetables.election import Election
 
 
 class ScottishParliamentElection(Election):
-    def __init__(self, poll_date: date):
+    def __init__(self, poll_date: dt.date):
         """
         :param poll_date: a datetime representing the date of the poll
         """
         Election.__init__(self, poll_date, Country.SCOTLAND)
 
     @property
-    def postal_vote_application_deadline(self) -> date:
+    def postal_vote_application_deadline(self) -> dt.date:
         """
         Calculates the postal vote application deadline for this Election
 
@@ -25,13 +25,13 @@ class ScottishParliamentElection(Election):
         :return: a datetime representing the postal vote application deadline
         """
 
-        if self.poll_date == date(2021, 5, 6):
+        if self.poll_date == dt.date(2021, 5, 6):
             return working_days_before(self.poll_date, 21, super()._calendar())
 
         return super().postal_vote_application_deadline
 
     @property
-    def sopn_publish_date(self) -> date:
+    def sopn_publish_date(self) -> dt.date:
         """
         Calculate the publish date for an election to the Scottish Parliament
 

--- a/uk_election_timetables/elections/senedd_cymru.py
+++ b/uk_election_timetables/elections/senedd_cymru.py
@@ -1,18 +1,18 @@
-from datetime import date
+import datetime as dt
 
 from uk_election_timetables.calendars import Country, working_days_before
 from uk_election_timetables.election import Election
 
 
 class SeneddCymruElection(Election):
-    def __init__(self, poll_date: date):
+    def __init__(self, poll_date: dt.date):
         """
         :param poll_date: a datetime representing the date of the poll
         """
         Election.__init__(self, poll_date, Country.WALES)
 
     @property
-    def sopn_publish_date(self) -> date:
+    def sopn_publish_date(self) -> dt.date:
         """
         Calculate the publish date for an election to the Senedd Cymru / Welsh Parliament
 

--- a/uk_election_timetables/elections/uk_parliament.py
+++ b/uk_election_timetables/elections/uk_parliament.py
@@ -1,11 +1,11 @@
-from datetime import date
+import datetime as dt
 
 from uk_election_timetables.calendars import Country, working_days_before
 from uk_election_timetables.election import Election
 
 
 class UKParliamentElection(Election):
-    def __init__(self, poll_date: date, country: Country = None):
+    def __init__(self, poll_date: dt.date, country: Country = None):
         """
         :param poll_date: a datetime representing the date of the poll
         :param country: an optional Country representing the country where the election will be held
@@ -13,7 +13,7 @@ class UKParliamentElection(Election):
         Election.__init__(self, poll_date, country)
 
     @property
-    def sopn_publish_date(self) -> date:
+    def sopn_publish_date(self) -> dt.date:
         """
         Calculate the publish date for an election to the Parliament of the United Kingdom
 
@@ -35,7 +35,7 @@ class UKParliamentElection(Election):
         ]
         return min(possible_dates)
 
-    def date_for_country(self, country: Country) -> date:
+    def date_for_country(self, country: Country) -> dt.date:
         calendar = type(self).BANK_HOLIDAY_CALENDAR.from_country(country)
 
         return working_days_before(self.poll_date, 19, calendar)


### PR DESCRIPTION
In this PR, I have implemented the `import datetime as dt` pattern from https://adamj.eu/tech/2019/09/12/how-i-import-pythons-datetime-module/ This library uses python's stdlib `datetime` module a lot, so this is quite a long PR but also this is a case where being really clear about this has some real benefit.

Rather than slogging through this myself, I told a language model to do it for me and did a quick check over the output.

Refs https://github.com/DemocracyClub/uk-election-timetables/pull/57#discussion_r3435491927