### PR TITLE
delete Region enum

### DIFF
--- a/uk_election_timetables/calendars.py
+++ b/uk_election_timetables/calendars.py
@@ -19,25 +19,6 @@ class Country(Enum):
     WALES = 4
 
 
-class Region(Enum):
-    """
-    The regions of the United Kingdom and Gibraltar as elected in the EU Parliament
-    """
-
-    EAST_MIDLANDS = 1
-    EAST_OF_ENGLAND = 2
-    LONDON = 3
-    NORTH_EAST_ENGLAND = 4
-    NORTH_WEST_ENGLAND = 5
-    NORTHERN_IRELAND = 6
-    SCOTLAND = 7
-    SOUTH_EAST_ENGLAND = 8
-    SOUTH_WEST_ENGLAND = 9
-    WALES = 10
-    WEST_MIDLANDS = 11
-    YORKSHIRE_AND_THE_HUMBER = 12
-
-
 class BaseCalendar(ABC):
     @abstractmethod
     def exempted_dates(self):


### PR DESCRIPTION
This used to be used for EU Parliament elections but that code was removed in ~2020 so we can bin it now. Technically this is a breaking change but nothing that consumes this library is actually using it so consequence-free.