### PR TITLE
refactor: Christmas Eve cleanup

### DIFF
--- a/uk_election_timetables/calendars.py
+++ b/uk_election_timetables/calendars.py
@@ -42,8 +42,6 @@ class BankHolidayCalendar(BaseCalendar):
         )
 
     def __init__(self, dates):
-        christmas_eve = DateMatcher(month=12, day=24)
-
         days_not_counted = [
             BankHolidayCalendar.create_matcher_from_entry(entry)
             for entry in dates
@@ -51,10 +49,8 @@ class BankHolidayCalendar(BaseCalendar):
 
         self._bank_holidays = days_not_counted
 
-        self._exempted_dates = self._bank_holidays + [christmas_eve]
-
     def exempted_dates(self):
-        return self._exempted_dates
+        return self._bank_holidays
 
 
 class UnitedKingdomBankHolidays:
@@ -137,7 +133,7 @@ class ExtendedCalendar(BaseCalendar):
             d
             for rule in rules
             for y in years
-            for d in rule.generate(y, base._bank_holidays)
+            for d in rule.generate(y, base.exempted_dates())
         ]
         self._all_dates = base.exempted_dates() + extra
 
@@ -165,6 +161,17 @@ class EasterMondayRule(ExcludedDateRule):
                 day=easter_monday.day,
             )
         ]
+
+
+class ChristmasEveRule(ExcludedDateRule):
+    def generate(
+        self, year: int, bank_holidays: List[DateMatcher]
+    ) -> List[DateMatcher]:
+        """
+        Christmas Eve is a bank holiday but most legislation
+        explicity considers it a "non-working" day anyway.
+        """
+        return [DateMatcher(name="Christmas Eve", year=year, month=12, day=24)]
 
 
 def working_days_before(

--- a/uk_election_timetables/election.py
+++ b/uk_election_timetables/election.py
@@ -5,6 +5,7 @@ from enum import Enum
 from typing import Dict, List
 
 from uk_election_timetables.calendars import (
+    ChristmasEveRule,
     Country,
     ExtendedCalendar,
     UnitedKingdomBankHolidays,
@@ -107,7 +108,13 @@ class Election(metaclass=ABCMeta):
         return sorted(dates, key=lambda r: r["date"])
 
     def _calendar(self):
-        return self.BANK_HOLIDAY_CALENDAR.from_country(self.country)
+        return ExtendedCalendar(
+            self.BANK_HOLIDAY_CALENDAR.from_country(self.country),
+            # by default, always consider Christmas Eve a non-working
+            # day, even though it is not a bank holiday
+            rules=[ChristmasEveRule()],
+            years=[self.poll_date.year - 1, self.poll_date.year],
+        )
 
     def get_extended_calendar(self, rules):
         return ExtendedCalendar(

--- a/uk_election_timetables/elections/uk_parliament.py
+++ b/uk_election_timetables/elections/uk_parliament.py
@@ -1,6 +1,11 @@
 import datetime as dt
 
-from uk_election_timetables.calendars import Country, working_days_before
+from uk_election_timetables.calendars import (
+    ChristmasEveRule,
+    Country,
+    ExtendedCalendar,
+    working_days_before,
+)
 from uk_election_timetables.election import Election
 
 
@@ -36,6 +41,10 @@ class UKParliamentElection(Election):
         return min(possible_dates)
 
     def date_for_country(self, country: Country) -> dt.date:
-        calendar = type(self).BANK_HOLIDAY_CALENDAR.from_country(country)
+        calendar = ExtendedCalendar(
+            type(self).BANK_HOLIDAY_CALENDAR.from_country(country),
+            rules=[ChristmasEveRule()],
+            years=[self.poll_date.year - 1, self.poll_date.year],
+        )
 
         return working_days_before(self.poll_date, 19, calendar)


### PR DESCRIPTION
This is just a little refactor that helps clean up the terminology a bit - it doesn't make any functional changes.

Before this refactor, `BankHolidayCalendar` contained Christmas Eve and `UnitedKingdomBankHolidays` returned a `BankHolidayCalendar` containing Christmas Eve.

Christmas Eve is notably not a bank holiday in any part of the UK.

This refactor changes it so that `BankHolidayCalendar` and `UnitedKingdomBankHolidays` now actually do what they say in the tin. `Election._calendar()` now returns an `ExtendedCalendar` object that includes Christmas Eve instead of a `BankHolidayCalendar` object.

Also, if we find that actually Christmas Eve is considered a working day in some context then it is easier to change from this starting point.