### PR TITLE
add notice of election deadline

### DIFF
--- a/tests/elections/test_city_of_london_local.py
+++ b/tests/elections/test_city_of_london_local.py
@@ -65,6 +65,20 @@ def test_city_of_london_sopn_date(election):
     )
 
 
+def test_notice_of_election_deadline():
+    """
+    note: this test is just reverse-engineered from the code
+
+    There is no local.city-of-london.2021-05-06
+
+    Replace it with a test based on a real-world example
+    when we have one to hand.
+    """
+    election = CityOfLondonLocalElection(dt.date(2021, 5, 6))
+
+    assert election.notice_of_election_deadline == dt.date(2021, 3, 25)
+
+
 def test_easter_break():
     rule = EasterBreakRule()
     # Test by example: 2022

--- a/tests/elections/test_greater_london_assembly.py
+++ b/tests/elections/test_greater_london_assembly.py
@@ -26,3 +26,10 @@ def test_registration_deadline_london_assembly():
     election = GreaterLondonAssemblyElection(dt.date(2021, 5, 6))
 
     assert election.registration_deadline == dt.date(2021, 4, 19)
+
+
+# Reference election: gla.2024-05-02
+def test_notice_of_election_deadline():
+    election = GreaterLondonAssemblyElection(dt.date(2024, 5, 2))
+
+    assert election.notice_of_election_deadline == dt.date(2024, 3, 19)

--- a/tests/elections/test_local.py
+++ b/tests/elections/test_local.py
@@ -46,3 +46,33 @@ def test_postal_vote_application_deadline_local_election_northern_ireland():
     ).postal_vote_application_deadline
 
     assert deadline == dt.date(2023, 4, 26)
+
+
+# Reference election: local.2026-05-07
+def test_notice_of_election_deadline_england():
+    election = LocalElection(dt.date(2026, 5, 7), country=Country.ENGLAND)
+
+    assert election.notice_of_election_deadline == dt.date(2026, 3, 30)
+
+
+# Reference election: local.2022-05-05
+def test_notice_of_election_deadline_scotland():
+    election = LocalElection(dt.date(2022, 5, 5), country=Country.SCOTLAND)
+
+    assert election.notice_of_election_deadline == dt.date(2022, 3, 23)
+
+
+def test_notice_of_election_deadline_northern_ireland():
+    """
+    note: this test is just reverse-engineered from the code
+
+    There were no local elections in Northern Ireland in 2026
+
+    Replace it with a test based on a real-world example
+    when we have one to hand (TODO: 2027)
+    """
+    election = LocalElection(
+        dt.date(2026, 5, 7), country=Country.NORTHERN_IRELAND
+    )
+
+    assert election.notice_of_election_deadline == dt.date(2026, 3, 30)

--- a/tests/elections/test_mayoral.py
+++ b/tests/elections/test_mayoral.py
@@ -22,3 +22,10 @@ def test_postal_vote_application_deadline_mayor():
     election = MayoralElection(dt.date(2021, 5, 6))
 
     assert election.postal_vote_application_deadline == dt.date(2021, 4, 20)
+
+
+# Reference election: mayor.2025-05-01
+def test_notice_of_election_deadline():
+    election = MayoralElection(dt.date(2025, 5, 1))
+
+    assert election.notice_of_election_deadline == dt.date(2025, 3, 25)

--- a/tests/elections/test_northern_ireland_assembly.py
+++ b/tests/elections/test_northern_ireland_assembly.py
@@ -10,3 +10,10 @@ def test_publish_date_northern_ireland_assembly():
     ).sopn_publish_date
 
     assert publish_date == dt.date(2017, 2, 8)
+
+
+# Reference election: nia.2022-05-05
+def test_notice_of_election_deadline():
+    election = NorthernIrelandAssemblyElection(dt.date(2022, 5, 5))
+
+    assert election.notice_of_election_deadline == dt.date(2022, 3, 28)

--- a/tests/elections/test_police_and_crime_commissioner.py
+++ b/tests/elections/test_police_and_crime_commissioner.py
@@ -22,3 +22,10 @@ def test_postal_vote_application_deadline_police_and_crime_commissioner():
     election = PoliceAndCrimeCommissionerElection(dt.date(2021, 5, 6))
 
     assert election.postal_vote_application_deadline == dt.date(2021, 4, 20)
+
+
+# Reference election: pcc.2026-05-07
+def test_notice_of_election_deadline():
+    election = PoliceAndCrimeCommissionerElection(dt.date(2024, 5, 2))
+
+    assert election.notice_of_election_deadline == dt.date(2024, 3, 26)

--- a/tests/elections/test_scottish_parliament.py
+++ b/tests/elections/test_scottish_parliament.py
@@ -44,3 +44,10 @@ def test_postal_vote_application_deadline_scottish_parliament():
     election = ScottishParliamentElection(dt.date(2021, 5, 6))
 
     assert election.postal_vote_application_deadline == dt.date(2021, 4, 6)
+
+
+# Reference election: sp.2026-05-07
+def test_notice_of_election_deadline():
+    election = ScottishParliamentElection(dt.date(2026, 5, 7))
+
+    assert election.notice_of_election_deadline == dt.date(2026, 3, 25)

--- a/tests/elections/test_senedd_cymru.py
+++ b/tests/elections/test_senedd_cymru.py
@@ -22,3 +22,10 @@ def test_postal_vote_application_deadline_senedd_cymru():
     election = SeneddCymruElection(dt.date(2021, 5, 6))
 
     assert election.postal_vote_application_deadline == dt.date(2021, 4, 20)
+
+
+# Reference election: senedd.2026-05-07
+def test_notice_of_election_deadline():
+    election = SeneddCymruElection(dt.date(2026, 5, 7))
+
+    assert election.notice_of_election_deadline == dt.date(2026, 3, 30)

--- a/tests/elections/test_uk_parliament.py
+++ b/tests/elections/test_uk_parliament.py
@@ -50,6 +50,13 @@ def test_postal_vote_application_deadline_uk_parliament_2019():
     assert election.postal_vote_application_deadline == dt.date(2019, 11, 26)
 
 
+# Reference election: parl.2024-07-04
+def test_notice_of_election_deadline():
+    election = UKParliamentElection(dt.date(2024, 7, 4))
+
+    assert election.notice_of_election_deadline == dt.date(2024, 6, 4)
+
+
 @pytest.mark.parametrize(
     "country, deadline_date",
     [

--- a/tests/test_election.py
+++ b/tests/test_election.py
@@ -46,9 +46,14 @@ def test_timetable_vac_application_deadline():
 def test_timetable_sort_order():
     election = from_election_id("local.2021-05-06", country=Country.ENGLAND)
 
-    assert len(election.timetable) == 4
+    assert len(election.timetable) == 5
 
     assert election.timetable == [
+        {
+            "label": "Notice of election deadline",
+            "date": dt.date(2021, 3, 29),
+            "event": "NOTICE_OF_ELECTION_DEADLINE",
+        },
         {
             "label": "List of candidates published",
             "date": dt.date(2021, 4, 8),
@@ -75,9 +80,14 @@ def test_timetable_sort_order():
 def test_timetable_sort_order_scottish_parliament_postal_vote():
     election = from_election_id("sp.c.2021-05-06")
 
-    assert len(election.timetable) == 4
+    assert len(election.timetable) == 5
 
     assert election.timetable == [
+        {
+            "label": "Notice of election deadline",
+            "date": dt.date(2021, 3, 24),
+            "event": "NOTICE_OF_ELECTION_DEADLINE",
+        },
         {
             "label": "List of candidates published",
             "date": dt.date(2021, 3, 31),
@@ -148,6 +158,10 @@ def test_get_date_for_event_type():
 
 
 def test_event_type_enum():
+    assert (
+        TimetableEvent.NOTICE_OF_ELECTION_DEADLINE.value
+        == "Notice of election deadline"
+    )
     assert (
         TimetableEvent.REGISTRATION_DEADLINE.value
         == "Register to vote deadline"

--- a/uk_election_timetables/election.py
+++ b/uk_election_timetables/election.py
@@ -60,6 +60,11 @@ class Election(metaclass=ABCMeta):
         pass
 
     @property
+    @abstractmethod
+    def notice_of_election_deadline(self) -> dt.date:
+        pass
+
+    @property
     def registration_deadline(self) -> dt.date:
         """
         Calculates the voter registration deadline for this Election

--- a/uk_election_timetables/election.py
+++ b/uk_election_timetables/election.py
@@ -14,6 +14,7 @@ from uk_election_timetables.calendars import (
 
 
 class TimetableEvent(Enum):
+    NOTICE_OF_ELECTION_DEADLINE = "Notice of election deadline"
     REGISTRATION_DEADLINE = "Register to vote deadline"
     SOPN_PUBLISH_DATE = "List of candidates published"
     POSTAL_VOTE_APPLICATION_DEADLINE = "Postal vote application deadline"
@@ -83,7 +84,18 @@ class Election(metaclass=ABCMeta):
         :return: a list representing the entire timetable for this particular election.
         """
 
-        dates = [
+        dates = []
+
+        with contextlib.suppress(NotImplementedError):
+            dates.append(
+                {
+                    "label": TimetableEvent.NOTICE_OF_ELECTION_DEADLINE.value,
+                    "date": self.notice_of_election_deadline,
+                    "event": TimetableEvent.NOTICE_OF_ELECTION_DEADLINE.name,
+                }
+            )
+
+        dates += [
             {
                 "label": TimetableEvent.REGISTRATION_DEADLINE.value,
                 "date": self.registration_deadline,

--- a/uk_election_timetables/elections/city_of_london_local.py
+++ b/uk_election_timetables/elections/city_of_london_local.py
@@ -120,3 +120,17 @@ class CityOfLondonLocalElection(Election):
         if self.poll_date <= dt.date(self.poll_date.year, 2, 15):
             return dt.date(self.poll_date.year - 2, 11, 30)
         return dt.date(self.poll_date.year - 1, 11, 30)
+
+    @property
+    def notice_of_election_deadline(self) -> dt.date:
+        """
+        Calculate the deadline for publishing a Notice of Election document for City of London Common Council or Alderman election
+
+        The same exceptions for Christmas and Easter breaks that we use for the SOPN date apply here.
+
+        :return: a datetime.date representing the expected publish date
+        """
+        calendar = self.get_extended_calendar(
+            [EasterBreakRule(), ChristmasBreakRule()]
+        )
+        return working_days_before(self.poll_date, 25, calendar)

--- a/uk_election_timetables/elections/greater_london_assembly.py
+++ b/uk_election_timetables/elections/greater_london_assembly.py
@@ -21,3 +21,12 @@ class GreaterLondonAssemblyElection(Election):
         :return: a datetime representing the expected publish date
         """
         return working_days_before(self.poll_date, 22, super()._calendar())
+
+    @property
+    def notice_of_election_deadline(self) -> dt.date:
+        """
+        Calculate the deadline for publishing a Notice of Election document for an election to the Greater London Assembly
+
+        :return: datetime.date representing the deadline to publish
+        """
+        return working_days_before(self.poll_date, 30, super()._calendar())

--- a/uk_election_timetables/elections/local.py
+++ b/uk_election_timetables/elections/local.py
@@ -17,7 +17,7 @@ class LocalElection(Election):
         This is set out in:
 
          * `The Local Elections (Principal Areas) (England and Wales) (Amendment) Rules 2014 <https://www.legislation.gov.uk/uksi/2014/494/made>`_
-         * `The Local Elections (Northern Ireland) Order 2010 <https://www.legislation.gov.uk/uksi/2010/2977/schedule/1/part/4/made>`_
+         * `The Local Elections (Northern Ireland) Order 2010 <https://www.legislation.gov.uk/uksi/2010/2977/schedule/1/part/4/made>`_ and its amendments
          * `The Scottish Local Government Elections Order 2011 <https://www.legislation.gov.uk/ssi/2011/399/made>`_
 
         :return: a datetime representing the expected publish date
@@ -28,6 +28,38 @@ class LocalElection(Election):
             Country.NORTHERN_IRELAND: 16,
             Country.SCOTLAND: 23,
             Country.WALES: 19,
+        }
+
+        days_prior = country_specific_duration[self.country]
+
+        calendar = super()._calendar()
+        if self.country == Country.SCOTLAND:
+            calendar = self.get_extended_calendar([EasterMondayRule()])
+
+        return working_days_before(
+            self.poll_date,
+            days_prior,
+            calendar,
+        )
+
+    @property
+    def notice_of_election_deadline(self) -> dt.date:
+        """
+        Calculate the deadline for publishing a Notice of Election document for a local election
+
+        This is set out in:
+
+         * `The Local Elections (Principal Areas) (England and Wales) (Amendment) Rules 2014 <https://www.legislation.gov.uk/uksi/2014/494/made>`_
+         * `The Local Elections (Northern Ireland) Order 2010 <https://www.legislation.gov.uk/uksi/2010/2977/schedule/1/part/4/made>`_ and its amendments
+         * `The Scottish Local Government Elections Order 2011 <https://www.legislation.gov.uk/ssi/2011/399/made>`_
+
+        :return: datetime.date representing the deadline to publish
+        """
+        country_specific_duration = {
+            Country.ENGLAND: 25,
+            Country.NORTHERN_IRELAND: 25,
+            Country.SCOTLAND: 28,
+            Country.WALES: 25,
         }
 
         days_prior = country_specific_duration[self.country]

--- a/uk_election_timetables/elections/mayor.py
+++ b/uk_election_timetables/elections/mayor.py
@@ -23,3 +23,16 @@ class MayoralElection(Election):
         :return: a datetime representing the expected publish date
         """
         return working_days_before(self.poll_date, 19, super()._calendar())
+
+    @property
+    def notice_of_election_deadline(self) -> dt.date:
+        """
+        Calculate the deadline for publishing a Notice of Election document for an election to the position of Mayor in England and Wales
+
+        This is set out in
+        - `The Local Authorities (Mayoral Elections) (England and Wales) (Amendment) Regulations 2014 <https://www.legislation.gov.uk/uksi/2014/370/made>`_
+        - `The Combined Authorities (Mayoral Elections) Order 2017 <https://www.legislation.gov.uk/uksi/2017/67/made>`_
+
+        :return: datetime.date representing the deadline to publish
+        """
+        return working_days_before(self.poll_date, 25, super()._calendar())

--- a/uk_election_timetables/elections/northern_ireland_assembly.py
+++ b/uk_election_timetables/elections/northern_ireland_assembly.py
@@ -21,3 +21,14 @@ class NorthernIrelandAssemblyElection(Election):
         :return: a datetime representing the expected publish date
         """
         return working_days_before(self.poll_date, 16, super()._calendar())
+
+    @property
+    def notice_of_election_deadline(self) -> dt.date:
+        """
+        Calculate the deadline for publishing a Notice of Election document for an election to the Northern Ireland Assembly
+
+        This is set out by Schedule 5, Rules 1 and 2 of `The Northern Ireland Assembly (Elections) (Amendment) Order 2009 <https://www.legislation.gov.uk/uksi/2009/256/made>`_
+
+        :return: datetime.date representing the deadline to publish
+        """
+        return working_days_before(self.poll_date, 25, super()._calendar())

--- a/uk_election_timetables/elections/police_and_crime_commissioner.py
+++ b/uk_election_timetables/elections/police_and_crime_commissioner.py
@@ -21,3 +21,14 @@ class PoliceAndCrimeCommissionerElection(Election):
         :return: a datetime representing the expected publish date
         """
         return working_days_before(self.poll_date, 18, super()._calendar())
+
+    @property
+    def notice_of_election_deadline(self) -> dt.date:
+        """
+        Calculate the deadline for publishing a Notice of Election document for an election to the position of Police and Crime Commissioner
+
+        This is set out in `The Police and Crime Commissioner Elections (Amendment) Order 2014 <https://www.legislation.gov.uk/uksi/2014/921/article/31/made>`_
+
+        :return: datetime.date representing the deadline to publish
+        """
+        return working_days_before(self.poll_date, 25, super()._calendar())

--- a/uk_election_timetables/elections/referendum.py
+++ b/uk_election_timetables/elections/referendum.py
@@ -7,3 +7,9 @@ class Referendum(Election):
     @property
     def sopn_publish_date(self) -> dt.date:
         raise NotImplementedError("No SOPN date for referenda")
+
+    @property
+    def notice_of_election_deadline(self) -> dt.date:
+        raise NotImplementedError(
+            "No Notice of Election Deadline for referenda"
+        )

--- a/uk_election_timetables/elections/scottish_parliament.py
+++ b/uk_election_timetables/elections/scottish_parliament.py
@@ -41,3 +41,15 @@ class ScottishParliamentElection(Election):
         """
         calendar = self.get_extended_calendar([EasterMondayRule()])
         return working_days_before(self.poll_date, 23, calendar)
+
+    @property
+    def notice_of_election_deadline(self) -> dt.date:
+        """
+        Calculate the deadline for publishing a Notice of Election document for an election to the Scottish Parliament
+
+        This is set out in `The Scottish Parliament (Elections etc.) Order 2015 <https://www.legislation.gov.uk/ssi/2015/425/made>`_
+
+        :return: datetime.date representing the deadline to publish
+        """
+        calendar = self.get_extended_calendar([EasterMondayRule()])
+        return working_days_before(self.poll_date, 28, calendar)

--- a/uk_election_timetables/elections/senedd_cymru.py
+++ b/uk_election_timetables/elections/senedd_cymru.py
@@ -21,3 +21,12 @@ class SeneddCymruElection(Election):
         :return: a datetime representing the expected publish date
         """
         return working_days_before(self.poll_date, 19, super()._calendar())
+
+    @property
+    def notice_of_election_deadline(self) -> dt.date:
+        """
+        Calculate the deadline for publishing a Notice of Election document for an election to the Senedd Cymru / Welsh Parliament
+
+        :return: datetime.date representing the deadline to publish
+        """
+        return working_days_before(self.poll_date, 25, super()._calendar())

--- a/uk_election_timetables/elections/uk_parliament.py
+++ b/uk_election_timetables/elections/uk_parliament.py
@@ -27,11 +27,13 @@ class UKParliamentElection(Election):
         :return: a datetime representing the expected publish date
         """
 
+        days_prior = 19
+
         if self.country:
-            return self.date_for_country(self.country)
+            return self.date_for_country(days_prior, self.country)
 
         possible_dates = [
-            self.date_for_country(country)
+            self.date_for_country(days_prior, country)
             for country in [
                 Country.ENGLAND,
                 Country.SCOTLAND,
@@ -40,11 +42,34 @@ class UKParliamentElection(Election):
         ]
         return min(possible_dates)
 
-    def date_for_country(self, country: Country) -> dt.date:
+    @property
+    def notice_of_election_deadline(self) -> dt.date:
+        """
+        Calculate the deadline for publishing a Notice of Election document for an election to the Parliament of the United Kingdom
+
+        :return: datetime.date representing the deadline to publish
+        """
+
+        days_prior = 22
+
+        if self.country:
+            return self.date_for_country(days_prior, self.country)
+
+        possible_dates = [
+            self.date_for_country(days_prior, country)
+            for country in [
+                Country.ENGLAND,
+                Country.SCOTLAND,
+                Country.NORTHERN_IRELAND,
+            ]
+        ]
+        return min(possible_dates)
+
+    def date_for_country(self, days: int, country: Country) -> dt.date:
         calendar = ExtendedCalendar(
             type(self).BANK_HOLIDAY_CALENDAR.from_country(country),
             rules=[ChristmasEveRule()],
             years=[self.poll_date.year - 1, self.poll_date.year],
         )
 
-        return working_days_before(self.poll_date, 19, calendar)
+        return working_days_before(self.poll_date, days, calendar)


### PR DESCRIPTION
This PR adds a `.notice_of_election_deadline` deadline property to the Election class and implements it for each of the election types.

This one is a real "devil is in the details" job, so I am going to leave a lot of very specific inline comments.