### PR TITLE
fix docstrings

### DIFF
--- a/uk_election_timetables/election.py
+++ b/uk_election_timetables/election.py
@@ -36,7 +36,7 @@ class Election(metaclass=ABCMeta):
 
         In Northern Ireland, this is set out in `The Representation of the People (Northern Ireland) Regulations 2008 <https://www.legislation.gov.uk/uksi/2008/1741/regulation/61/made>`
 
-        :return: a datetime representing the postal vote application deadline
+        :return: datetime.date representing the postal vote application deadline
         """
         if self.country == Country.NORTHERN_IRELAND:
             return working_days_before(self.poll_date, 14, self._calendar())
@@ -66,7 +66,7 @@ class Election(metaclass=ABCMeta):
 
         This explained in a `background note from the Electoral Commission <https://www.electoralcommission.org.uk/media/2457>`_
 
-        :return: a datetime representing the voter registration deadline
+        :return: datetime.date representing the voter registration deadline
         """
         return working_days_before(self.poll_date, 12, self._calendar())
 

--- a/uk_election_timetables/election_ids.py
+++ b/uk_election_timetables/election_ids.py
@@ -75,7 +75,7 @@ def from_election_id(election_id: str, country: Country = None) -> Election:
 
     :param election_id: a string representing an election id in uk-election-ids format
     :param country: an optional Country representing the country where the election will be held
-    :return: a datetime representing the expected publish date
+    :return: Election object
     """
     election_id_lookup = {
         "nia": NorthernIrelandAssemblyElection,

--- a/uk_election_timetables/elections/city_of_london_local.py
+++ b/uk_election_timetables/elections/city_of_london_local.py
@@ -75,7 +75,7 @@ class ChristmasBreakRule(ExcludedDateRule):
 class CityOfLondonLocalElection(Election):
     def __init__(self, poll_date: dt.date):
         """
-        :param poll_date: a datetime representing the date of the poll
+        :param poll_date: datetime.date representing the date of the poll
         """
         Election.__init__(self, poll_date, Country.ENGLAND)
 
@@ -102,7 +102,7 @@ class CityOfLondonLocalElection(Election):
         means the period beginning with the Thursday before and ending with the
         Tuesday after Easter Day;
 
-        :return: a datetime representing the expected publish date
+        :return: datetime.date representing the expected publish date
         """
 
         calendar = self.get_extended_calendar(
@@ -115,7 +115,7 @@ class CityOfLondonLocalElection(Election):
         """
         Calculates the voter registration deadline for a City of London local election.
 
-        :return: a datetime representing the voter registration deadline
+        :return: datetime.date representing the voter registration deadline
         """
         if self.poll_date <= dt.date(self.poll_date.year, 2, 15):
             return dt.date(self.poll_date.year - 2, 11, 30)

--- a/uk_election_timetables/elections/greater_london_assembly.py
+++ b/uk_election_timetables/elections/greater_london_assembly.py
@@ -7,7 +7,7 @@ from uk_election_timetables.election import Election
 class GreaterLondonAssemblyElection(Election):
     def __init__(self, poll_date: dt.date):
         """
-        :param poll_date: a datetime representing the date of the poll
+        :param poll_date: datetime.date representing the date of the poll
         """
         Election.__init__(self, poll_date, Country.ENGLAND)
 
@@ -18,6 +18,6 @@ class GreaterLondonAssemblyElection(Election):
 
         This is set out in `The Greater London Authority Elections (Amendment) Rules 2016 <https://www.legislation.gov.uk/uksi/2016/24/article/6/made>`_
 
-        :return: a datetime representing the expected publish date
+        :return: datetime.date representing the expected publish date
         """
         return working_days_before(self.poll_date, 22, super()._calendar())

--- a/uk_election_timetables/elections/local.py
+++ b/uk_election_timetables/elections/local.py
@@ -20,7 +20,7 @@ class LocalElection(Election):
          * `The Local Elections (Northern Ireland) Order 2010 <https://www.legislation.gov.uk/uksi/2010/2977/schedule/1/part/4/made>`_
          * `The Scottish Local Government Elections Order 2011 <https://www.legislation.gov.uk/ssi/2011/399/made>`_
 
-        :return: a datetime representing the expected publish date
+        :return: datetime.date representing the expected publish date
         """
 
         country_specific_duration = {

--- a/uk_election_timetables/elections/mayor.py
+++ b/uk_election_timetables/elections/mayor.py
@@ -7,7 +7,7 @@ from uk_election_timetables.election import Election
 class MayoralElection(Election):
     def __init__(self, poll_date: dt.date):
         """
-        :param poll_date: a datetime representing the date of the poll
+        :param poll_date: datetime.date representing the date of the poll
         """
         Election.__init__(self, poll_date, Country.ENGLAND)
 
@@ -20,6 +20,6 @@ class MayoralElection(Election):
         - `The Local Authorities (Mayoral Elections) (England and Wales) (Amendment) Regulations 2014 <https://www.legislation.gov.uk/uksi/2014/370/made>`_
         - `The Combined Authorities (Mayoral Elections) Order 2017 <https://www.legislation.gov.uk/uksi/2017/67/made>`_
 
-        :return: a datetime representing the expected publish date
+        :return: datetime.date representing the expected publish date
         """
         return working_days_before(self.poll_date, 19, super()._calendar())

--- a/uk_election_timetables/elections/northern_ireland_assembly.py
+++ b/uk_election_timetables/elections/northern_ireland_assembly.py
@@ -7,7 +7,7 @@ from uk_election_timetables.election import Election
 class NorthernIrelandAssemblyElection(Election):
     def __init__(self, poll_date: dt.date):
         """
-        :param poll_date: a datetime representing the date of the poll
+        :param poll_date: datetime.date representing the date of the poll
         """
         Election.__init__(self, poll_date, Country.NORTHERN_IRELAND)
 
@@ -18,6 +18,6 @@ class NorthernIrelandAssemblyElection(Election):
 
         This is set out by Schedule 5, Rules 1 and 2 of `The Northern Ireland Assembly (Elections) (Amendment) Order 2009 <https://www.legislation.gov.uk/uksi/2009/256/made>`_
 
-        :return: a datetime representing the expected publish date
+        :return: datetime.date representing the expected publish date
         """
         return working_days_before(self.poll_date, 16, super()._calendar())

--- a/uk_election_timetables/elections/police_and_crime_commissioner.py
+++ b/uk_election_timetables/elections/police_and_crime_commissioner.py
@@ -7,7 +7,7 @@ from uk_election_timetables.election import Election
 class PoliceAndCrimeCommissionerElection(Election):
     def __init__(self, poll_date: dt.date):
         """
-        :param poll_date: a datetime representing the date of the poll
+        :param poll_date: datetime.date representing the date of the poll
         """
         Election.__init__(self, poll_date, Country.ENGLAND)
 
@@ -18,6 +18,6 @@ class PoliceAndCrimeCommissionerElection(Election):
 
         This is set out in `The Police and Crime Commissioner Elections (Amendment) Order 2014 <https://www.legislation.gov.uk/uksi/2014/921/article/31/made>`_
 
-        :return: a datetime representing the expected publish date
+        :return: datetime.date representing the expected publish date
         """
         return working_days_before(self.poll_date, 18, super()._calendar())

--- a/uk_election_timetables/elections/scottish_parliament.py
+++ b/uk_election_timetables/elections/scottish_parliament.py
@@ -11,7 +11,7 @@ from uk_election_timetables.election import Election
 class ScottishParliamentElection(Election):
     def __init__(self, poll_date: dt.date):
         """
-        :param poll_date: a datetime representing the date of the poll
+        :param poll_date: datetime.date representing the date of the poll
         """
         Election.__init__(self, poll_date, Country.SCOTLAND)
 
@@ -22,7 +22,7 @@ class ScottishParliamentElection(Election):
 
         This is set out in `Scottish General Election (Coronavirus) Act 2021 <https://www.legislation.gov.uk/asp/2021/5/crossheading/postal-voting-arrangements-for-2021-election>`_.
 
-        :return: a datetime representing the postal vote application deadline
+        :return: datetime.date representing the postal vote application deadline
         """
 
         if self.poll_date == dt.date(2021, 5, 6):
@@ -37,7 +37,7 @@ class ScottishParliamentElection(Election):
 
         This is set out in `The Scottish Parliament (Elections etc.) Order 2015 <https://www.legislation.gov.uk/ssi/2015/425/made>`_
 
-        :return: a datetime representing the expected publish date
+        :return: datetime.date representing the expected publish date
         """
         calendar = self.get_extended_calendar([EasterMondayRule()])
         return working_days_before(self.poll_date, 23, calendar)

--- a/uk_election_timetables/elections/senedd_cymru.py
+++ b/uk_election_timetables/elections/senedd_cymru.py
@@ -7,7 +7,7 @@ from uk_election_timetables.election import Election
 class SeneddCymruElection(Election):
     def __init__(self, poll_date: dt.date):
         """
-        :param poll_date: a datetime representing the date of the poll
+        :param poll_date: datetime.date representing the date of the poll
         """
         Election.__init__(self, poll_date, Country.WALES)
 
@@ -18,6 +18,6 @@ class SeneddCymruElection(Election):
 
         This is set out in `Senedd and Elections (Wales) Act 2020 <https://www.legislation.gov.uk/anaw/2020/1/contents>` and `The National Assembly for Wales (Representation of the People) (Amendment) Order 2016 <https://www.legislation.gov.uk/uksi/2016/272/article/18/made>`_
 
-        :return: a datetime representing the expected publish date
+        :return: datetime.date representing the expected publish date
         """
         return working_days_before(self.poll_date, 19, super()._calendar())

--- a/uk_election_timetables/elections/uk_parliament.py
+++ b/uk_election_timetables/elections/uk_parliament.py
@@ -12,7 +12,7 @@ from uk_election_timetables.election import Election
 class UKParliamentElection(Election):
     def __init__(self, poll_date: dt.date, country: Country = None):
         """
-        :param poll_date: a datetime representing the date of the poll
+        :param poll_date: datetime.date representing the date of the poll
         :param country: an optional Country representing the country where the election will be held
         """
         Election.__init__(self, poll_date, country)
@@ -24,7 +24,7 @@ class UKParliamentElection(Election):
 
         This is set out in `Representation of the People Act 1983 <https://www.legislation.gov.uk/ukpga/1983/2/contents>`_ and its amendments.
 
-        :return: a datetime representing the expected publish date
+        :return: datetime.date representing the expected publish date
         """
 
         if self.country:


### PR DESCRIPTION
While I was working on https://github.com/DemocracyClub/uk-election-timetables/pull/61 I noticed a lot of problems with docstrings. Mostly functions that return a `datetime.date` documented as returning a `datetime`. All the new functions I added in https://github.com/DemocracyClub/uk-election-timetables/pull/61 say

```
:return: datetime.date bla bla bla
```

This PR aligns all the existing ones.

Rather than slogging through this myself, I told a language model to do it for me and did a quick check over the output.