### PR TITLE
separate "Close of Nominations" and "SOPN Publish Deadline"

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ from uk_election_timetables.elections.uk_parliament import UKParliamentElection
 
 election = UKParliamentElection(date(2019, 2, 21))
 
-print(election.sopn_publish_date) # date(2019, 1, 25)
+print(election.close_of_nominations) # date(2019, 1, 25)
 ```
 
 ## Updating Bank Holiday Dates

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -16,7 +16,7 @@ from uk_election_timetables.elections.uk_parliament import UKParliamentElection
 
 election = UKParliamentElection(date(2019, 2, 21))
 
-print(election.sopn_publish_date) # date(2019, 1, 25)
+print(election.close_of_nominations) # date(2019, 1, 25)
 ```
  
 ## Installation

--- a/tests/elections/test_city_of_london_local.py
+++ b/tests/elections/test_city_of_london_local.py
@@ -41,18 +41,18 @@ sopn_test_cases = [
     {
         # https://candidates.democracyclub.org.uk/elections/local.city-of-london.cordwainer.by.2022-09-15/sopn/
         "poll_date": dt.date(2022, 9, 15),
-        "sopn_publish_date": dt.date(2022, 8, 23),
+        "close_of_nominations": dt.date(2022, 8, 22),
     },
     {
         # https://candidates.democracyclub.org.uk/elections/local.city-of-london.bassishaw.by.2019-04-30/sopn/
         # includes an easter break
         "poll_date": dt.date(2019, 4, 30),
-        "sopn_publish_date": dt.date(2019, 4, 2),
+        "close_of_nominations": dt.date(2019, 4, 1),
     },
     {
         # https://candidates.democracyclub.org.uk/elections/local.city-of-london-alder.cornhill.2022-05-26/sopn/
         "poll_date": dt.date(2022, 5, 26),
-        "sopn_publish_date": dt.date(2022, 5, 4),
+        "close_of_nominations": dt.date(2022, 5, 3),
     },
 ]
 
@@ -60,8 +60,8 @@ sopn_test_cases = [
 @pytest.mark.parametrize("election", sopn_test_cases)
 def test_city_of_london_sopn_date(election):
     assert (
-        CityOfLondonLocalElection(election["poll_date"]).sopn_publish_date
-        == election["sopn_publish_date"]
+        CityOfLondonLocalElection(election["poll_date"]).close_of_nominations
+        == election["close_of_nominations"]
     )
 
 

--- a/tests/elections/test_greater_london_assembly.py
+++ b/tests/elections/test_greater_london_assembly.py
@@ -7,7 +7,7 @@ from uk_election_timetables.elections import GreaterLondonAssemblyElection
 def test_publish_date_greater_london_assembly():
     publish_date = GreaterLondonAssemblyElection(
         dt.date(2016, 5, 5)
-    ).sopn_publish_date
+    ).close_of_nominations
 
     assert publish_date == dt.date(2016, 4, 4)
 
@@ -16,7 +16,7 @@ def test_publish_date_greater_london_assembly():
 def test_publish_date_mayor_london():
     publish_date = GreaterLondonAssemblyElection(
         dt.date(2016, 5, 5)
-    ).sopn_publish_date
+    ).close_of_nominations
 
     assert publish_date == dt.date(2016, 4, 4)
 

--- a/tests/elections/test_local.py
+++ b/tests/elections/test_local.py
@@ -8,21 +8,21 @@ from uk_election_timetables.elections import LocalElection
 def test_publish_date_scottish_local():
     election = LocalElection(dt.date(2018, 12, 6), Country.SCOTLAND)
 
-    assert election.sopn_publish_date == dt.date(2018, 11, 2)
+    assert election.close_of_nominations == dt.date(2018, 11, 2)
 
 
 # Reference election: local.belfast.balmoral.2019-05-02
 def test_publish_date_northern_ireland_local():
     election = LocalElection(dt.date(2019, 5, 2), Country.NORTHERN_IRELAND)
 
-    assert election.sopn_publish_date == dt.date(2019, 4, 8)
+    assert election.close_of_nominations == dt.date(2019, 4, 8)
 
 
 # Reference election: local.herefordshire.ross-north.2019-06-06
 def test_publish_date_local_election_england():
     election = LocalElection(dt.date(2019, 6, 6), country=Country.ENGLAND)
 
-    assert election.sopn_publish_date == dt.date(2019, 5, 9)
+    assert election.close_of_nominations == dt.date(2019, 5, 9)
 
 
 # Reference election: local.2021-05-06

--- a/tests/elections/test_mayoral.py
+++ b/tests/elections/test_mayoral.py
@@ -7,7 +7,7 @@ from uk_election_timetables.elections import MayoralElection
 def test_publish_date_mayor():
     election = MayoralElection(dt.date(2017, 5, 4))
 
-    assert election.sopn_publish_date == dt.date(2017, 4, 4)
+    assert election.close_of_nominations == dt.date(2017, 4, 4)
 
 
 # Reference election: mayor.2021-05-06

--- a/tests/elections/test_northern_ireland_assembly.py
+++ b/tests/elections/test_northern_ireland_assembly.py
@@ -7,7 +7,7 @@ from uk_election_timetables.elections import NorthernIrelandAssemblyElection
 def test_publish_date_northern_ireland_assembly():
     publish_date = NorthernIrelandAssemblyElection(
         dt.date(2017, 3, 2)
-    ).sopn_publish_date
+    ).close_of_nominations
 
     assert publish_date == dt.date(2017, 2, 8)
 

--- a/tests/elections/test_police_and_crime_commissioner.py
+++ b/tests/elections/test_police_and_crime_commissioner.py
@@ -7,7 +7,7 @@ from uk_election_timetables.elections import PoliceAndCrimeCommissionerElection
 def test_publish_date_police_and_crime_commissioner():
     election = PoliceAndCrimeCommissionerElection(dt.date(2016, 5, 5))
 
-    assert election.sopn_publish_date == dt.date(2016, 4, 8)
+    assert election.close_of_nominations == dt.date(2016, 4, 8)
 
 
 # Reference election: pcc.2021-05-06

--- a/tests/elections/test_scottish_parliament.py
+++ b/tests/elections/test_scottish_parliament.py
@@ -12,14 +12,14 @@ sopn_test_cases = [
         # https://candidates.democracyclub.org.uk/elections/sp.c.shetland-islands.2021-05-06/sopn/
         # In 2021 Easter Monday fell between SOPN Publish date and polling day
         "poll_date": dt.date(2021, 5, 6),
-        "sopn_publish_date": dt.date(2021, 3, 31),
+        "close_of_nominations": dt.date(2021, 3, 31),
     },
     {
         # Reference election: sp.c.shetland-islands.2016-05-05
         # https://candidates.democracyclub.org.uk/elections/sp.c.shetland-islands.2016-05-05/sopn/
         # In 2016 Easter Monday was on 27th March so does not factor in here
         "poll_date": dt.date(2016, 5, 5),
-        "sopn_publish_date": dt.date(2016, 4, 1),
+        "close_of_nominations": dt.date(2016, 4, 1),
     },
 ]
 
@@ -27,8 +27,8 @@ sopn_test_cases = [
 @pytest.mark.parametrize("election", sopn_test_cases)
 def test_publish_date_scottish_parliament(election):
     assert (
-        ScottishParliamentElection(election["poll_date"]).sopn_publish_date
-        == election["sopn_publish_date"]
+        ScottishParliamentElection(election["poll_date"]).close_of_nominations
+        == election["close_of_nominations"]
     )
 
 

--- a/tests/elections/test_senedd_cymru.py
+++ b/tests/elections/test_senedd_cymru.py
@@ -5,7 +5,7 @@ from uk_election_timetables.elections import SeneddCymruElection
 
 # Reference election: naw.c.ceredigion.2016-05-05
 def test_publish_date_senedd_cymru():
-    publish_date = SeneddCymruElection(dt.date(2016, 5, 5)).sopn_publish_date
+    publish_date = SeneddCymruElection(dt.date(2016, 5, 5)).close_of_nominations
 
     assert publish_date == dt.date(2016, 4, 7)
 

--- a/tests/elections/test_uk_parliament.py
+++ b/tests/elections/test_uk_parliament.py
@@ -10,14 +10,14 @@ from uk_election_timetables.elections import UKParliamentElection
 def test_publish_date_uk_parliament_wales():
     election = UKParliamentElection(dt.date(2017, 6, 8), Country.WALES)
 
-    assert election.sopn_publish_date == dt.date(2017, 5, 11)
+    assert election.close_of_nominations == dt.date(2017, 5, 11)
 
 
 # Reference election: parl.na-h-eileanan-an-iar.2017-06-08
 def test_publish_date_uk_parliament_scotland():
     election = UKParliamentElection(dt.date(2017, 6, 8), Country.SCOTLAND)
 
-    assert election.sopn_publish_date == dt.date(2017, 5, 11)
+    assert election.close_of_nominations == dt.date(2017, 5, 11)
 
 
 # Reference election: parl.belfast-east.2017-06-08
@@ -26,21 +26,21 @@ def test_publish_date_uk_parliament_northern_ireland():
         dt.date(2017, 6, 8), Country.NORTHERN_IRELAND
     )
 
-    assert election.sopn_publish_date == dt.date(2017, 5, 11)
+    assert election.close_of_nominations == dt.date(2017, 5, 11)
 
 
 # Reference election: parl.hemel-hempstead.2017-06-08
 def test_publish_date_uk_parliament_england():
     election = UKParliamentElection(dt.date(2017, 6, 8), Country.ENGLAND)
 
-    assert election.sopn_publish_date == dt.date(2017, 5, 11)
+    assert election.close_of_nominations == dt.date(2017, 5, 11)
 
 
 # Reference election: parl.2019-12-12
 def test_publish_date_uk_parliament_2019():
     election = UKParliamentElection(dt.date(2019, 12, 12))
 
-    assert election.sopn_publish_date == dt.date(2019, 11, 14)
+    assert election.close_of_nominations == dt.date(2019, 11, 14)
 
 
 # Reference election: parl.2019-12-12

--- a/tests/test_close_of_nominations.py
+++ b/tests/test_close_of_nominations.py
@@ -31,19 +31,19 @@ def test_publish_date_local_id():
 def test_publish_date_local_id_with_country():
     election = from_election_id("local.2019-02-21", country=Country.ENGLAND)
 
-    assert election.sopn_publish_date == dt.date(2019, 1, 25)
+    assert election.close_of_nominations == dt.date(2019, 1, 25)
 
 
 def test_publish_date_parl_id_with_country():
     election = from_election_id("parl.2019-02-21", country=Country.ENGLAND)
 
-    assert election.sopn_publish_date == dt.date(2019, 1, 25)
+    assert election.close_of_nominations == dt.date(2019, 1, 25)
 
 
 def test_publish_date_parl_id_without_country():
     election = from_election_id("parl.2019-02-21")
 
-    assert election.sopn_publish_date == dt.date(2019, 1, 25)
+    assert election.close_of_nominations == dt.date(2019, 1, 25)
 
 
 def test_publish_date_not_an_election_type():
@@ -56,7 +56,7 @@ def test_publish_date_not_an_election_type():
 def test_publish_date_id_that_does_not_need_country():
     election = from_election_id("naw.c.ceredigion.2016-05-05")
 
-    assert election.sopn_publish_date == dt.date(2016, 4, 7)
+    assert election.close_of_nominations == dt.date(2016, 4, 7)
 
 
 def test_publish_date_invalid_id():
@@ -82,13 +82,13 @@ def test_publish_date_invalid_date():
 def test_publish_date_senedd_election_id():
     election = from_election_id("senedd.c.ceredigion.2016-05-05")
 
-    assert election.sopn_publish_date == dt.date(2016, 4, 7)
+    assert election.close_of_nominations == dt.date(2016, 4, 7)
 
 
 def test_publish_date_referendum():
     ref = from_election_id("ref.2019-02-21", country=Country.ENGLAND)
     with raises(NotImplementedError) as err:
-        ref.sopn_publish_date
+        ref.close_of_nominations
 
     assert str(err.value) == "No SOPN date for referenda"
 
@@ -104,5 +104,6 @@ def test_christmas_eve_not_counted():
 
     for election_on, expected_date in election_and_expected_sopn_date.items():
         assert (
-            election_on(dt.date(2019, 1, 10)).sopn_publish_date == expected_date
+            election_on(dt.date(2019, 1, 10)).close_of_nominations
+            == expected_date
         )

--- a/tests/test_date.py
+++ b/tests/test_date.py
@@ -2,26 +2,33 @@ import datetime as dt
 
 import pytest
 
-from uk_election_timetables.date import DateMatcher, days_before, easter_sunday
+from uk_election_timetables.date import DateMatcher, days_diff, easter_sunday
 
 
-def test_zero_days_before():
+def test_zero_days_diff():
     example = dt.date(2020, 1, 1)
 
-    assert days_before(example, 0) == example
+    assert days_diff(example, 0) == example
 
 
-def test_non_zero_days_before():
+def test_negative_days_diff():
     example = dt.date(2020, 1, 1)
 
-    assert days_before(example, 1) == dt.date(2019, 12, 31)
-    assert days_before(example, 2) == dt.date(2019, 12, 30)
+    assert days_diff(example, -1) == dt.date(2019, 12, 31)
+    assert days_diff(example, -2) == dt.date(2019, 12, 30)
+
+
+def test_positive_days_diff():
+    example = dt.date(2020, 1, 1)
+
+    assert days_diff(example, 1) == dt.date(2020, 1, 2)
+    assert days_diff(example, 2) == dt.date(2020, 1, 3)
 
 
 def test_ignore_weekends():
     example = dt.date(2020, 1, 6)  # Monday
 
-    assert days_before(example, 1) == dt.date(2020, 1, 3)
+    assert days_diff(example, -1) == dt.date(2020, 1, 3)
 
 
 def test_ignore_exempted_day_with_year():
@@ -29,7 +36,7 @@ def test_ignore_exempted_day_with_year():
 
     exempted_dates = [DateMatcher(year=2019, month=12, day=31)]
 
-    assert days_before(example, 1, exempted_dates) == dt.date(2019, 12, 30)
+    assert days_diff(example, -1, exempted_dates) == dt.date(2019, 12, 30)
 
 
 def test_ignore_exempted_day_without_year():
@@ -37,7 +44,7 @@ def test_ignore_exempted_day_without_year():
 
     exempted_dates = [DateMatcher(month=12, day=31)]
 
-    assert days_before(example, 1, exempted_dates) == dt.date(2019, 12, 30)
+    assert days_diff(example, -1, exempted_dates) == dt.date(2019, 12, 30)
 
 
 # vendored from dateutil

--- a/tests/test_election.py
+++ b/tests/test_election.py
@@ -9,12 +9,12 @@ from uk_election_timetables.election import Election, TimetableEvent
 from uk_election_timetables.election_ids import from_election_id
 
 
-def test_timetable_sopn_publish_date():
+def test_timetable_close_of_nominations():
     election = from_election_id("parl.2019-02-21", country=Country.ENGLAND)
 
-    sopn_publish_date = lookup(election, "Close of Nominations")
+    close_of_nominations = lookup(election, "Close of Nominations")
 
-    assert sopn_publish_date["date"] == dt.date(2019, 1, 25)
+    assert close_of_nominations["date"] == dt.date(2019, 1, 25)
 
 
 def test_timetable_registration_deadline():

--- a/tests/test_election.py
+++ b/tests/test_election.py
@@ -303,14 +303,14 @@ def test_from_election_types_types(election):
 def test_city_of_london_does_not_mutate_global_calendar():
     assert from_election_id(
         "mayor.doncaster.2025-05-01", Country.ENGLAND
-    ).sopn_publish_date == dt.date(2025, 4, 2)
+    ).close_of_nominations == dt.date(2025, 4, 2)
 
     assert from_election_id(
         "local.city-of-london.aldersgate.2025-03-20", Country.ENGLAND
-    ).sopn_publish_date == dt.date(2025, 2, 26)
+    ).close_of_nominations == dt.date(2025, 2, 25)
 
     # calculating the date for a City of London election
     # shouldn't change this result
     assert from_election_id(
         "mayor.doncaster.2025-05-01", Country.ENGLAND
-    ).sopn_publish_date == dt.date(2025, 4, 2)
+    ).close_of_nominations == dt.date(2025, 4, 2)

--- a/tests/test_election.py
+++ b/tests/test_election.py
@@ -12,7 +12,7 @@ from uk_election_timetables.election_ids import from_election_id
 def test_timetable_sopn_publish_date():
     election = from_election_id("parl.2019-02-21", country=Country.ENGLAND)
 
-    sopn_publish_date = lookup(election, "List of candidates published")
+    sopn_publish_date = lookup(election, "Close of Nominations")
 
     assert sopn_publish_date["date"] == dt.date(2019, 1, 25)
 
@@ -46,7 +46,7 @@ def test_timetable_vac_application_deadline():
 def test_timetable_sort_order():
     election = from_election_id("local.2021-05-06", country=Country.ENGLAND)
 
-    assert len(election.timetable) == 5
+    assert len(election.timetable) == 6
 
     assert election.timetable == [
         {
@@ -55,9 +55,14 @@ def test_timetable_sort_order():
             "event": "NOTICE_OF_ELECTION_DEADLINE",
         },
         {
-            "label": "List of candidates published",
+            "label": "Close of Nominations",
             "date": dt.date(2021, 4, 8),
-            "event": "SOPN_PUBLISH_DATE",
+            "event": "CLOSE_OF_NOMINATIONS",
+        },
+        {
+            "label": "SOPN publishing deadline",
+            "date": dt.date(2021, 4, 9),
+            "event": "SOPN_PUBLISH_DEADLINE",
         },
         {
             "label": "Register to vote deadline",
@@ -80,7 +85,7 @@ def test_timetable_sort_order():
 def test_timetable_sort_order_scottish_parliament_postal_vote():
     election = from_election_id("sp.c.2021-05-06")
 
-    assert len(election.timetable) == 5
+    assert len(election.timetable) == 6
 
     assert election.timetable == [
         {
@@ -89,9 +94,14 @@ def test_timetable_sort_order_scottish_parliament_postal_vote():
             "event": "NOTICE_OF_ELECTION_DEADLINE",
         },
         {
-            "label": "List of candidates published",
+            "label": "Close of Nominations",
             "date": dt.date(2021, 3, 31),
-            "event": "SOPN_PUBLISH_DATE",
+            "event": "CLOSE_OF_NOMINATIONS",
+        },
+        {
+            "label": "SOPN publishing deadline",
+            "date": dt.date(2021, 4, 1),
+            "event": "SOPN_PUBLISH_DEADLINE",
         },
         {
             "label": "Postal vote application deadline",
@@ -144,7 +154,7 @@ def lookup(election: Election, label: str) -> Dict:
 def test_get_date_for_event_type():
     election = from_election_id("parl.2019-02-21", country=Country.ENGLAND)
     assert election.get_date_for_event_type(
-        TimetableEvent("List of candidates published")
+        TimetableEvent("Close of Nominations")
     ) == dt.date(2019, 1, 25)
     assert election.get_date_for_event_type(
         TimetableEvent("Postal vote application deadline")
@@ -166,9 +176,7 @@ def test_event_type_enum():
         TimetableEvent.REGISTRATION_DEADLINE.value
         == "Register to vote deadline"
     )
-    assert (
-        TimetableEvent.SOPN_PUBLISH_DATE.value == "List of candidates published"
-    )
+    assert TimetableEvent.CLOSE_OF_NOMINATIONS.value == "Close of Nominations"
     assert (
         TimetableEvent.POSTAL_VOTE_APPLICATION_DEADLINE.value
         == "Postal vote application deadline"
@@ -182,7 +190,7 @@ def test_event_type_enum():
 def test_is_before():
     election = from_election_id("parl.2019-02-21", country=Country.ENGLAND)
     assert election.is_before(TimetableEvent.REGISTRATION_DEADLINE) is False
-    assert election.is_before(TimetableEvent.SOPN_PUBLISH_DATE) is False
+    assert election.is_before(TimetableEvent.CLOSE_OF_NOMINATIONS) is False
     assert (
         election.is_before(TimetableEvent.POSTAL_VOTE_APPLICATION_DEADLINE)
         is False
@@ -193,7 +201,7 @@ def test_is_before():
 def test_is_after():
     election = from_election_id("parl.2019-02-21", country=Country.ENGLAND)
     assert election.is_after(TimetableEvent.REGISTRATION_DEADLINE) is True
-    assert election.is_after(TimetableEvent.SOPN_PUBLISH_DATE) is True
+    assert election.is_after(TimetableEvent.CLOSE_OF_NOMINATIONS) is True
     assert (
         election.is_after(TimetableEvent.POSTAL_VOTE_APPLICATION_DEADLINE)
         is True

--- a/tests/test_historic_sopn_publish_dates.py
+++ b/tests/test_historic_sopn_publish_dates.py
@@ -3,7 +3,7 @@ from csv import DictReader
 
 from pytest import mark
 
-from uk_election_timetables.date import days_before
+from uk_election_timetables.date import days_diff
 from uk_election_timetables.elections import (
     GreaterLondonAssemblyElection,
     MayoralElection,
@@ -25,18 +25,18 @@ def read_date(date_as_string):
 
 
 def same_or_next_day(actual_date, expected_date):
-    return days_before(actual_date, 1) <= expected_date <= actual_date
+    return days_diff(actual_date, -1) <= expected_date <= actual_date
 
 
 def no_later_than(actual_date, expected_date):
     # We use "up to 3 days before" as a test heuristic, it's good enough
-    return days_before(expected_date, 3) <= actual_date <= expected_date
+    return days_diff(expected_date, -3) <= actual_date <= expected_date
 
 
 def within_one_day(actual_date, expected_date):
     return same_or_next_day(
         actual_date, expected_date
-    ) or actual_date == days_before(expected_date, 1)
+    ) or actual_date == days_diff(expected_date, -1)
 
 
 def generate_test_id(val):
@@ -57,7 +57,9 @@ def generate_test_cases(search, exceptions=None):
 def test_northern_ireland_assembly(row):
     poll_date = read_date(row["election_date"])
 
-    expected_date = NorthernIrelandAssemblyElection(poll_date).sopn_publish_date
+    expected_date = NorthernIrelandAssemblyElection(
+        poll_date
+    ).close_of_nominations
 
     actual_date = read_date(row["sopn_publish_date"])
 
@@ -68,7 +70,7 @@ def test_northern_ireland_assembly(row):
 def test_scottish_parliament(row):
     poll_date = read_date(row["election_date"])
 
-    expected_date = ScottishParliamentElection(poll_date).sopn_publish_date
+    expected_date = ScottishParliamentElection(poll_date).close_of_nominations
 
     actual_date = read_date(row["sopn_publish_date"])
 
@@ -79,7 +81,7 @@ def test_scottish_parliament(row):
 def test_old_national_assembly_for_wales(row):
     poll_date = read_date(row["election_date"])
 
-    expected_date = SeneddCymruElection(poll_date).sopn_publish_date
+    expected_date = SeneddCymruElection(poll_date).close_of_nominations
 
     actual_date = read_date(row["sopn_publish_date"])
 
@@ -90,7 +92,9 @@ def test_old_national_assembly_for_wales(row):
 def test_greater_london_assembly(row):
     poll_date = read_date(row["election_date"])
 
-    expected_date = GreaterLondonAssemblyElection(poll_date).sopn_publish_date
+    expected_date = GreaterLondonAssemblyElection(
+        poll_date
+    ).close_of_nominations
 
     actual_date = read_date(row["sopn_publish_date"])
 
@@ -103,7 +107,7 @@ def test_police_and_crime_commissioner(row):
 
     expected_date = PoliceAndCrimeCommissionerElection(
         poll_date
-    ).sopn_publish_date
+    ).close_of_nominations
 
     actual_date = read_date(row["sopn_publish_date"])
 
@@ -118,7 +122,7 @@ def test_police_and_crime_commissioner(row):
 def test_mayoral(row):
     poll_date = read_date(row["election_date"])
 
-    expected_date = MayoralElection(poll_date).sopn_publish_date
+    expected_date = MayoralElection(poll_date).close_of_nominations
 
     actual_date = read_date(row["sopn_publish_date"])
 
@@ -131,7 +135,9 @@ def test_mayoral(row):
 def test_mayor_of_london(row):
     poll_date = read_date(row["election_date"])
 
-    expected_date = GreaterLondonAssemblyElection(poll_date).sopn_publish_date
+    expected_date = GreaterLondonAssemblyElection(
+        poll_date
+    ).close_of_nominations
 
     actual_date = read_date(row["sopn_publish_date"])
 
@@ -142,7 +148,7 @@ def test_mayor_of_london(row):
 def test_uk_parliament(row):
     poll_date = read_date(row["election_date"])
 
-    expected_date = UKParliamentElection(poll_date).sopn_publish_date
+    expected_date = UKParliamentElection(poll_date).close_of_nominations
 
     actual_date = read_date(row["sopn_publish_date"])
 

--- a/uk_election_timetables/calendars.py
+++ b/uk_election_timetables/calendars.py
@@ -5,7 +5,7 @@ from abc import ABC, abstractmethod
 from enum import Enum
 from typing import List
 
-from uk_election_timetables.date import DateMatcher, days_before, easter_sunday
+from uk_election_timetables.date import DateMatcher, days_diff, easter_sunday
 
 
 class Country(Enum):
@@ -186,4 +186,19 @@ def working_days_before(
     :return: the calculated date
     """
 
-    return days_before(end_date, days, calendar.exempted_dates())
+    return days_diff(end_date, 0 - days, calendar.exempted_dates())
+
+
+def working_days_after(
+    base_date: dt.date, days: int, calendar: BaseCalendar
+) -> dt.date:
+    """
+    Return date corresponding to `count` working days after `base_date` according to the given bank holiday calendar
+
+    :param base_date: the date to count from
+    :param days: the number of days to count
+    :param calendar: the bank holiday calendar used in the calculation
+    :return: the calculated date
+    """
+
+    return days_diff(base_date, days, calendar.exempted_dates())

--- a/uk_election_timetables/date.py
+++ b/uk_election_timetables/date.py
@@ -39,30 +39,34 @@ class DateMatcher:
         return True
 
 
-def days_before(
-    poll_date: dt.date, days: int, ignore: List[DateMatcher] = None
+def days_diff(
+    base_date: dt.date, days: int, ignore: List[DateMatcher] = None
 ) -> dt.date:
     """
-    Return date corresponding to `days` working days before `poll_date`, not counting the list of provided exemptions
+    Return date corresponding to `days` working days before or after `base_date`,
+    not counting the list of provided exemptions.
 
-    :param poll_date: the date of the poll
-    :param days: the number of days before the poll date
-    :param ignore: the list of DateMatchers to ignore in the look-back calculation
+    :param base_date: the reference date
+    :param days: the number of working days to offset; positive = after, negative = before
+    :param ignore: the list of DateMatchers to ignore in the calculation
     :return: the calculated date
     """
+    delta = 1 if days > 0 else -1
+    step = dt.timedelta(days=delta)
+    remaining = abs(days)
 
-    while days > 0:
-        poll_date -= dt.timedelta(days=1)
+    while remaining > 0:
+        base_date += step
 
-        if poll_date.weekday() in WEEKEND:
+        if base_date.weekday() in WEEKEND:
             continue
 
-        if ignore and any(day.matches(poll_date) for day in ignore):
+        if ignore and any(day.matches(base_date) for day in ignore):
             continue
 
-        days -= 1
+        remaining -= 1
 
-    return poll_date
+    return base_date
 
 
 def easter_sunday(year: int) -> dt.date:

--- a/uk_election_timetables/election.py
+++ b/uk_election_timetables/election.py
@@ -1,5 +1,6 @@
 import contextlib
 import datetime as dt
+import warnings
 from abc import ABCMeta, abstractmethod
 from enum import Enum
 from typing import Dict, List
@@ -9,6 +10,7 @@ from uk_election_timetables.calendars import (
     Country,
     ExtendedCalendar,
     UnitedKingdomBankHolidays,
+    working_days_after,
     working_days_before,
 )
 
@@ -16,7 +18,8 @@ from uk_election_timetables.calendars import (
 class TimetableEvent(Enum):
     NOTICE_OF_ELECTION_DEADLINE = "Notice of election deadline"
     REGISTRATION_DEADLINE = "Register to vote deadline"
-    SOPN_PUBLISH_DATE = "List of candidates published"
+    CLOSE_OF_NOMINATIONS = "Close of Nominations"
+    SOPN_PUBLISH_DEADLINE = "SOPN publishing deadline"
     POSTAL_VOTE_APPLICATION_DEADLINE = "Postal vote application deadline"
     VAC_APPLICATION_DEADLINE = "VAC application deadline"
 
@@ -57,13 +60,36 @@ class Election(metaclass=ABCMeta):
 
     @property
     @abstractmethod
-    def sopn_publish_date(self) -> dt.date:
+    def notice_of_election_deadline(self) -> dt.date:
         pass
 
     @property
     @abstractmethod
-    def notice_of_election_deadline(self) -> dt.date:
+    def close_of_nominations(self) -> dt.date:
         pass
+
+    @property
+    def sopn_publish_deadline(self) -> dt.date:
+        """
+        Calculates the deadline after which a SOPN must be published
+
+        :return: datetime.date representing the SOPN publish deadline
+        """
+        return working_days_after(
+            self.close_of_nominations, 1, self._calendar()
+        )
+
+    @property
+    def sopn_publish_date(self) -> dt.date:
+        """
+        Alias for close_of_nominations
+        Deprecated
+        """
+        warnings.warn(
+            "Deprecated. Use 'close_of_nominations' or 'sopn_publish_deadline' instead",
+            DeprecationWarning,
+        )
+        return self.close_of_nominations
 
     @property
     def registration_deadline(self) -> dt.date:
@@ -116,9 +142,16 @@ class Election(metaclass=ABCMeta):
         with contextlib.suppress(NotImplementedError):
             dates.append(
                 {
-                    "label": TimetableEvent.SOPN_PUBLISH_DATE.value,
-                    "date": self.sopn_publish_date,
-                    "event": TimetableEvent.SOPN_PUBLISH_DATE.name,
+                    "label": TimetableEvent.CLOSE_OF_NOMINATIONS.value,
+                    "date": self.close_of_nominations,
+                    "event": TimetableEvent.CLOSE_OF_NOMINATIONS.name,
+                }
+            )
+            dates.append(
+                {
+                    "label": TimetableEvent.SOPN_PUBLISH_DEADLINE.value,
+                    "date": self.sopn_publish_deadline,
+                    "event": TimetableEvent.SOPN_PUBLISH_DEADLINE.name,
                 }
             )
 

--- a/uk_election_timetables/elections/city_of_london_local.py
+++ b/uk_election_timetables/elections/city_of_london_local.py
@@ -114,6 +114,13 @@ class CityOfLondonLocalElection(Election):
         return working_days_before(self.poll_date, 17, calendar)
 
     @property
+    def sopn_publish_deadline(self) -> dt.date:
+        calendar = self.get_extended_calendar(
+            [EasterBreakRule(), ChristmasBreakRule()]
+        )
+        return working_days_before(self.poll_date, 15, calendar)
+
+    @property
     def registration_deadline(self) -> dt.date:
         """
         Calculates the voter registration deadline for a City of London local election.

--- a/uk_election_timetables/elections/city_of_london_local.py
+++ b/uk_election_timetables/elections/city_of_london_local.py
@@ -80,18 +80,9 @@ class CityOfLondonLocalElection(Election):
         Election.__init__(self, poll_date, Country.ENGLAND)
 
     @property
-    def sopn_publish_date(self) -> dt.date:
+    def close_of_nominations(self) -> dt.date:
         """
         Calculate the "SOPN publish date" for a City of London local election.
-
-        There are actually 2 releavant dates here:
-        The SOPN is _published_ **17 (working) days before polling day**
-        but then candidates can be withdrawn from it for an additional day
-        after that.
-        So the SOPN becomes _final_ **16 (working) days before polling day**
-
-        For the sake of simplicity, we are going to call 16 days before
-        polling day the "sopn_publish_date".
 
         As well as the usual exclusions for weekends and bank holidays,
         the City of London also exclude a Christmas break and Easter break.
@@ -102,13 +93,25 @@ class CityOfLondonLocalElection(Election):
         means the period beginning with the Thursday before and ending with the
         Tuesday after Easter Day;
 
+        Note: There is an additional way that City of London is unusual here.
+
+        For all other election types, the withdrawal deadline aligns with
+        close_of_nominations. For City of London, it lines up with the
+        sopn_publish_deadline.
+
+        This means the first SOPN can be _published_
+        **17 (working) days before polling day**
+        but then candidates can be withdrawn from it for an additional day
+        after that.
+        So the SOPN becomes _final_ **16 (working) days before polling day**
+
         :return: datetime.date representing the expected publish date
         """
 
         calendar = self.get_extended_calendar(
             [EasterBreakRule(), ChristmasBreakRule()]
         )
-        return working_days_before(self.poll_date, 16, calendar)
+        return working_days_before(self.poll_date, 17, calendar)
 
     @property
     def registration_deadline(self) -> dt.date:

--- a/uk_election_timetables/elections/greater_london_assembly.py
+++ b/uk_election_timetables/elections/greater_london_assembly.py
@@ -12,7 +12,7 @@ class GreaterLondonAssemblyElection(Election):
         Election.__init__(self, poll_date, Country.ENGLAND)
 
     @property
-    def sopn_publish_date(self) -> dt.date:
+    def close_of_nominations(self) -> dt.date:
         """
         Calculate the publish date for an election to the Greater London Assembly
 

--- a/uk_election_timetables/elections/local.py
+++ b/uk_election_timetables/elections/local.py
@@ -10,7 +10,7 @@ from uk_election_timetables.election import Election
 
 class LocalElection(Election):
     @property
-    def sopn_publish_date(self) -> dt.date:
+    def close_of_nominations(self) -> dt.date:
         """
         Calculate the publish date for a local election.
 

--- a/uk_election_timetables/elections/local.py
+++ b/uk_election_timetables/elections/local.py
@@ -3,6 +3,7 @@ import datetime as dt
 from uk_election_timetables.calendars import (
     Country,
     EasterMondayRule,
+    working_days_after,
     working_days_before,
 )
 from uk_election_timetables.election import Election
@@ -41,6 +42,14 @@ class LocalElection(Election):
             days_prior,
             calendar,
         )
+
+    @property
+    def sopn_publish_deadline(self) -> dt.date:
+        calendar = super()._calendar()
+        if self.country == Country.SCOTLAND:
+            calendar = self.get_extended_calendar([EasterMondayRule()])
+
+        return working_days_after(self.close_of_nominations, 1, calendar)
 
     @property
     def notice_of_election_deadline(self) -> dt.date:

--- a/uk_election_timetables/elections/mayor.py
+++ b/uk_election_timetables/elections/mayor.py
@@ -12,7 +12,7 @@ class MayoralElection(Election):
         Election.__init__(self, poll_date, Country.ENGLAND)
 
     @property
-    def sopn_publish_date(self) -> dt.date:
+    def close_of_nominations(self) -> dt.date:
         """
         Calculate the publish date for an election to the position of Mayor in England and Wales
 

--- a/uk_election_timetables/elections/northern_ireland_assembly.py
+++ b/uk_election_timetables/elections/northern_ireland_assembly.py
@@ -12,7 +12,7 @@ class NorthernIrelandAssemblyElection(Election):
         Election.__init__(self, poll_date, Country.NORTHERN_IRELAND)
 
     @property
-    def sopn_publish_date(self) -> dt.date:
+    def close_of_nominations(self) -> dt.date:
         """
         Calculate the publish date for an election to the Northern Ireland Assembly
 

--- a/uk_election_timetables/elections/police_and_crime_commissioner.py
+++ b/uk_election_timetables/elections/police_and_crime_commissioner.py
@@ -12,7 +12,7 @@ class PoliceAndCrimeCommissionerElection(Election):
         Election.__init__(self, poll_date, Country.ENGLAND)
 
     @property
-    def sopn_publish_date(self) -> dt.date:
+    def close_of_nominations(self) -> dt.date:
         """
         Calculate the publish date for an election to the position of Police and Crime Commissioner
 

--- a/uk_election_timetables/elections/referendum.py
+++ b/uk_election_timetables/elections/referendum.py
@@ -5,7 +5,7 @@ from uk_election_timetables.election import Election
 
 class Referendum(Election):
     @property
-    def sopn_publish_date(self) -> dt.date:
+    def close_of_nominations(self) -> dt.date:
         raise NotImplementedError("No SOPN date for referenda")
 
     @property

--- a/uk_election_timetables/elections/scottish_parliament.py
+++ b/uk_election_timetables/elections/scottish_parliament.py
@@ -43,6 +43,11 @@ class ScottishParliamentElection(Election):
         return working_days_before(self.poll_date, 23, calendar)
 
     @property
+    def sopn_publish_deadline(self) -> dt.date:
+        calendar = self.get_extended_calendar([EasterMondayRule()])
+        return working_days_before(self.poll_date, 22, calendar)
+
+    @property
     def notice_of_election_deadline(self) -> dt.date:
         """
         Calculate the deadline for publishing a Notice of Election document for an election to the Scottish Parliament

--- a/uk_election_timetables/elections/scottish_parliament.py
+++ b/uk_election_timetables/elections/scottish_parliament.py
@@ -31,7 +31,7 @@ class ScottishParliamentElection(Election):
         return super().postal_vote_application_deadline
 
     @property
-    def sopn_publish_date(self) -> dt.date:
+    def close_of_nominations(self) -> dt.date:
         """
         Calculate the publish date for an election to the Scottish Parliament
 

--- a/uk_election_timetables/elections/senedd_cymru.py
+++ b/uk_election_timetables/elections/senedd_cymru.py
@@ -12,7 +12,7 @@ class SeneddCymruElection(Election):
         Election.__init__(self, poll_date, Country.WALES)
 
     @property
-    def sopn_publish_date(self) -> dt.date:
+    def close_of_nominations(self) -> dt.date:
         """
         Calculate the publish date for an election to the Senedd Cymru / Welsh Parliament
 

--- a/uk_election_timetables/elections/uk_parliament.py
+++ b/uk_election_timetables/elections/uk_parliament.py
@@ -18,7 +18,7 @@ class UKParliamentElection(Election):
         Election.__init__(self, poll_date, country)
 
     @property
-    def sopn_publish_date(self) -> dt.date:
+    def close_of_nominations(self) -> dt.date:
         """
         Calculate the publish date for an election to the Parliament of the United Kingdom
 


### PR DESCRIPTION
- rename `sopn_publish_date` to `close_of_nominations`
- alias `sopn_publish_date` to `close_of_nominations` with deprecation warning
- generalise `days_before` function so we can calculate days before or after some reference point
- add `sopn_publish_deadline` property, defined as `close_of_nominations` + 1 working day
- align City of London with everything else. `close_of_nominations` and `sopn_publish_deadline` have the same meaning there as everywhere else. We ignore the intricacy that the withdrawal deadline aligns with the `sopn_publish_deadline` instead of `close_of_nominations`